### PR TITLE
Add local Terraform credentials directory and mount

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -9,5 +9,8 @@
 			"tflint": "latest",
 			"terragrunt": "latest"
 		}
-	}
+	},
+	"mounts": [
+		"source=${localWorkspaceFolder}/.terraform.credentials.d,target=/home/vscode/.terraform.d,type=bind,consistency=cached"
+	]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Terraform configuration directory
+/.terraform.credentials.d/*
+!/.terraform.credentials.d/.keep

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # search-v2-infrastructure
 IaC definitions for GOV.UK Search v2
+
+## Development containers
+The workspace can be run as a devcontainer. A gitignored `.terraform.credentials.d` directory is
+included in the repository, which is mounted into the devcontainer's home folder for `tf login` to
+store Terraform Cloud tokens into (so they persist across container rebuilds). This directory will
+contain sensitive information, so do not stop it being gitignored or force any files within to be
+checked in.


### PR DESCRIPTION
This enables users to log in to Terraform Cloud and have their credentials persisted through container rebuilds.