### PR TITLE
Use REST API provider to provision Vertex resources

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -4,11 +4,8 @@
 	"name": "search-v2-infrastructure",
 	"image": "mcr.microsoft.com/devcontainers/base:bullseye",
 	"features": {
-		"ghcr.io/devcontainers/features/terraform:1": {
-			"version": "1.6.0",
-			"tflint": "latest",
-			"terragrunt": "latest"
-		}
+		"ghcr.io/devcontainers/features/terraform:1": {},
+		"ghcr.io/dhoeric/features/google-cloud-cli:1": {}
 	},
 	"mounts": [
 		"source=${localWorkspaceFolder}/.terraform.credentials.d,target=/home/vscode/.terraform.d,type=bind,consistency=cached"

--- a/variables.tf
+++ b/variables.tf
@@ -8,3 +8,21 @@ variable "gcp_region" {
   description = "GCP region to create non-global infrastructure in, e.g. europe-west2"
   default     = "europe-west2"
 }
+
+variable "gcp_vertex_location" {
+  type        = string
+  description = "GCP location to create Vertex Datastore instance in, e.g. global"
+  default     = "global"
+}
+
+variable "gcp_vertex_collection" {
+  type        = string
+  description = "The collection to use for Vertex Search, currently only `default_collection` is supported"
+  default     = "default_collection"
+}
+
+variable "gcp_vertex_data_store_id" {
+  type        = string
+  description = "The ID of the Vertex Datastore instance to create, e.g. search-api-v2-integration"
+  default     = "govuk-structured"
+}


### PR DESCRIPTION
This is a first attempt at provisioning Vertex over the GCP REST APIs.

- Add initial resource for Vertex datastore
- Add REST API provider and remove `gcloud` module (we can't use it)
- Add `gcloud` tooling to devcontainer