### PR TITLE
Finalise creation of datastore and schema

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -10,6 +10,9 @@
 	"mounts": [
 		"source=${localWorkspaceFolder}/.terraform.credentials.d,target=/home/vscode/.terraform.d,type=bind,consistency=cached"
 	],
+	"remoteEnv": {
+		"GOOGLE_APPLICATION_CREDENTIALS": "/home/vscode/.terraform.d/google_credentials.json"
+	},
 	"customizations": {
 		"vscode": {
 			"settings": {

--- a/discovery_engine.tf
+++ b/discovery_engine.tf
@@ -7,7 +7,7 @@ data "google_client_config" "default" {}
 # Using REST API provider as a "temporary" workaround, as there are no native Terraform resources
 # for Discovery Engine in the Google provider yet
 provider "restapi" {
-  uri = "https://discoveryengine.googleapis.com/${var.discovery_engine_api_version}/projects/${var.gcp_project_id}/locations/${var.discovery_engine_location}/collections/${var.discovery_engine_collection}"
+  uri = "https://discoveryengine.googleapis.com/${var.discovery_engine_api_version}/projects/${var.gcp_project_id}/locations/${var.discovery_engine_location}/collections/default_collection"
 
   # Writes return an "operation" reference rather than the object being written
   write_returns_object = false
@@ -31,14 +31,24 @@ resource "google_project_service" "discoveryengine" {
   disable_dependent_services = true
 }
 
-# A datastore for content to be ingested into
+# The datastore to store content in
+#
+# Currently (October 2023), the datastore is the core entity of the Discovery Engine API, used for
+# both querying and storing content. There are plans for this to change and for an "engine" resource
+# to be introduced, at which point we will need to create an engine and associate it with the
+# datastore.
+#
 # API resource: v1alpha.projects.locations.collections.dataStores
 resource "restapi_object" "discovery_engine_datastore" {
   depends_on = [google_project_service.discoveryengine]
-  path       = "/dataStores"
-  object_id  = var.discovery_engine_datastore_id
+
+  path      = "/dataStores"
+  object_id = var.discovery_engine_datastore_id
+
+  # API uses query strings to specify ID of the resource to create (not payload)
+  create_path = "/dataStores?dataStoreId=${var.discovery_engine_datastore_id}"
+
   data = jsonencode({
-    dataStoreId      = var.discovery_engine_datastore_id
     displayName      = var.discovery_engine_datastore_id
     industryVertical = "GENERIC"
     solutionTypes    = ["SOLUTION_TYPE_SEARCH"]
@@ -48,16 +58,25 @@ resource "restapi_object" "discovery_engine_datastore" {
   })
 }
 
-# The data schema for the datastore (while datastores only support a single schema, the API resource
-# relationship is one-to-many)
+# The data schema for the datastore
+#
+# The API resource relationship is one-to-many, but currently only a single schema is supported and
+# it's automatically created as `default_schema` (with an empty content) on creation of the
+# datastore.
+#
 # API resource: v1alpha.projects.locations.collections.dataStores.schemas
 resource "restapi_object" "discovery_engine_datastore_schema" {
-  depends_on   = [restapi_object.discovery_engine_datastore]
-  path         = "/dataStores/${var.discovery_engine_datastore_id}/schemas"
-  query_string = "schemaId=${var.discovery_engine_datastore_schema_name}"
-  object_id    = var.discovery_engine_datastore_schema_name
+  depends_on = [restapi_object.discovery_engine_datastore]
+
+  path      = "/dataStores/${restapi_object.discovery_engine_datastore.object_id}/schemas"
+  object_id = "default_schema"
+
+  # Since the default schema is created automatically with the datastore, we need to update even on
+  # initial Terraform resource creation
+  create_method = "PATCH"
+  create_path   = "/dataStores/${restapi_object.discovery_engine_datastore.object_id}/schemas/default_schema"
+
   data = jsonencode({
-    name         = var.discovery_engine_datastore_schema_name
-    structSchema = file("${path.module}/files/datastore_schema.json")
+    jsonSchema = file("${path.module}/files/datastore_schema.json")
   })
 }

--- a/files/datastore_schema.json
+++ b/files/datastore_schema.json
@@ -92,22 +92,25 @@
         "type": "object",
         "properties": {
           "title": {
-            "type": "string"
+            "type": "string",
+            "searchable": true,
+            "retrievable": true
           },
           "body": {
-            "type": "string"
+            "type": "string",
+            "searchable": true,
+            "retrievable": true
           },
           "slug": {
-            "type": "string"
+            "type": "string",
+            "retrievable": true
           }
         },
         "required": [
           "title",
           "slug"
         ]
-      },
-      "searchable": true,
-      "retrievable": true
+      }
     }
   },
   "required": [

--- a/variables.tf
+++ b/variables.tf
@@ -31,22 +31,8 @@ variable "discovery_engine_tier" {
   default     = "STANDARD"
 }
 
-variable "discovery_engine_collection" {
-  type        = string
-  description = "The collection to use for Discovery Engine"
-  # Defaulting to `default_collection` as this is the only supported collection (and we wouldn't
-  # need any custom collection anyway)
-  default = "default_collection"
-}
-
 variable "discovery_engine_datastore_id" {
   type        = string
   description = "The ID of the Discovery Engine Datastore instance to create, e.g. search-api-v2-integration"
   default     = "govuk-content"
-}
-
-variable "discovery_engine_datastore_schema_name" {
-  type        = string
-  description = "The name for the Discovery Engine Datastore's metadata schema"
-  default     = "govuk-content-metadata"
 }


### PR DESCRIPTION
- Make schema creation act as update (as default schema is automatically created with datastore)
- Remove unnecessary variables (the `default_*` IDs can just be hardcoded)
- Fix schema incorrectly specifying params on array rather than field level
- Add ability for devcontainer to mount Google credentials for running Terraform locally