### PR TITLE
base64decode Google key before persisting

### DIFF
--- a/service_accounts.tf
+++ b/service_accounts.tf
@@ -87,10 +87,10 @@ resource "aws_secretsmanager_secret" "key_write" {
 
 resource "aws_secretsmanager_secret_version" "key_read" {
   secret_id     = aws_secretsmanager_secret.key_read.id
-  secret_string = google_service_account_key.api_read.private_key
+  secret_string = base64decode(google_service_account_key.api_read.private_key)
 }
 
 resource "aws_secretsmanager_secret_version" "key_write" {
   secret_id     = aws_secretsmanager_secret.key_write.id
-  secret_string = google_service_account_key.api_write.private_key
+  secret_string = base64decode(google_service_account_key.api_write.private_key)
 }


### PR DESCRIPTION
Google service account private keys are base64 encoded, but we'd rather just store the raw value in Secrets Manager.