### PR TITLE
Don't base64 decode Google keys

### DIFF
--- a/service_accounts.tf
+++ b/service_accounts.tf
@@ -87,10 +87,10 @@ resource "aws_secretsmanager_secret" "key_write" {
 
 resource "aws_secretsmanager_secret_version" "key_read" {
   secret_id     = aws_secretsmanager_secret.key_read.id
-  secret_string = base64decode(google_service_account_key.api_read.private_key)
+  secret_string = google_service_account_key.api_read.private_key
 }
 
 resource "aws_secretsmanager_secret_version" "key_write" {
   secret_id     = aws_secretsmanager_secret.key_write.id
-  secret_string = base64decode(google_service_account_key.api_write.private_key)
+  secret_string = google_service_account_key.api_write.private_key
 }


### PR DESCRIPTION
Having them in Secrets Manager as base64 actually allows us to mount them as files more easily.