### PR TITLE
Nest Google credentials in SM under a top-level JSON key

### DIFF
--- a/service_accounts.tf
+++ b/service_accounts.tf
@@ -86,11 +86,15 @@ resource "aws_secretsmanager_secret" "key_write" {
 }
 
 resource "aws_secretsmanager_secret_version" "key_read" {
-  secret_id     = aws_secretsmanager_secret.key_read.id
-  secret_string = google_service_account_key.api_read.private_key
+  secret_id = aws_secretsmanager_secret.key_read.id
+  secret_string = jsonencode({
+    "credentials.json" = google_service_account_key.api_read.private_key
+  })
 }
 
 resource "aws_secretsmanager_secret_version" "key_write" {
-  secret_id     = aws_secretsmanager_secret.key_write.id
-  secret_string = google_service_account_key.api_write.private_key
+  secret_id = aws_secretsmanager_secret.key_write.id
+  secret_string = jsonencode({
+    "credentials.json" = google_service_account_key.api_write.private_key
+  })
 }


### PR DESCRIPTION
The pipeline around the external secrets Kubernetes operator tries to be overly "helpful" by treating top-level JSON as individual secrets, when what we _really_ want is the whole JSON as a single entity.

This nests the Google credentials JSON under a top-level key, which we can then extract using the external secrets operator as a single file.