### PR TITLE
Allow disabling of SA key generation

### DIFF
--- a/service_accounts.tf
+++ b/service_accounts.tf
@@ -71,30 +71,36 @@ resource "google_project_iam_binding" "api_write" {
 
 resource "google_service_account_key" "api_read" {
   service_account_id = google_service_account.api_read.id
+  count              = var.generate_google_keys ? 1 : 0
 }
 
 resource "google_service_account_key" "api_write" {
   service_account_id = google_service_account.api_write.id
+  count              = var.generate_google_keys ? 1 : 0
 }
 
 resource "aws_secretsmanager_secret" "key_read" {
-  name = "govuk/search-api-v2/google-key-read"
+  name  = "govuk/search-api-v2/google-key-read"
+  count = var.generate_google_keys ? 1 : 0
 }
 
 resource "aws_secretsmanager_secret" "key_write" {
-  name = "govuk/search-api-v2/google-key-write"
+  name  = "govuk/search-api-v2/google-key-write"
+  count = var.generate_google_keys ? 1 : 0
 }
 
 resource "aws_secretsmanager_secret_version" "key_read" {
-  secret_id = aws_secretsmanager_secret.key_read.id
+  secret_id = aws_secretsmanager_secret.key_read[count.index].id
   secret_string = jsonencode({
-    "credentials.json" = base64decode(google_service_account_key.api_read.private_key)
+    "credentials.json" = base64decode(google_service_account_key.api_read[count.index].private_key)
   })
+  count = var.generate_google_keys ? 1 : 0
 }
 
 resource "aws_secretsmanager_secret_version" "key_write" {
-  secret_id = aws_secretsmanager_secret.key_write.id
+  secret_id = aws_secretsmanager_secret.key_write[count.index].id
   secret_string = jsonencode({
-    "credentials.json" = base64decode(google_service_account_key.api_write.private_key)
+    "credentials.json" = base64decode(google_service_account_key.api_write[count.index].private_key)
   })
+  count = var.generate_google_keys ? 1 : 0
 }

--- a/variables.tf
+++ b/variables.tf
@@ -36,3 +36,9 @@ variable "discovery_engine_datastore_ids" {
   description = "A list of IDs for Discovery Engine Datastore instances to create"
   default     = ["govuk-content"]
 }
+
+variable "generate_google_keys" {
+  type        = bool
+  description = "Whether or not to generate Google service account keys (and import them into AWS Secrets Manager) for this environment"
+  default     = true
+}


### PR DESCRIPTION
We want to create a `dev` environment that has several engines for local use by the team, and doesn't actually have a deployed API. This allows disabling the generation of service account keys (and the import into AWS Secrets Manager) for a given workspace.