### PR TITLE
Manage GCP projects in `meta` module

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -8,11 +8,9 @@
 		"ghcr.io/dhoeric/features/google-cloud-cli:1": {}
 	},
 	"mounts": [
-		"source=${localWorkspaceFolder}/.terraform.credentials.d,target=/home/vscode/.terraform.d,type=bind,consistency=cached"
+		"source=${localWorkspaceFolder}/.terraform.credentials.d,target=/home/vscode/.terraform.d,type=bind,consistency=cached",
+		"source=${localWorkspaceFolder}/.google.credentials.d,target=/home/vscode/.config/gcloud,type=bind,consistency=cached"
 	],
-	"remoteEnv": {
-		"GOOGLE_APPLICATION_CREDENTIALS": "/home/vscode/.terraform.d/google_credentials.json"
-	},
 	"customizations": {
 		"vscode": {
 			"settings": {

--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,15 @@
 /.terraform.credentials.d/*
 !/.terraform.credentials.d/.keep
 
+# Google configuration directory
+/.google.credentials.d/*
+!/.google.credentials.d/.keep
+
 # Terraform
 .terraform
 *.tfstate
 *.tfstate.backup
 *.lock.hcl
+
+# Local configuration
+local.auto.tfvars

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ engineer with the required Google and Terraform Cloud access to bootstrap the in
 resources. You can also run plans for other modules locally.
 
 > **Warning**
-> A gitignored .terraform.credentials.d directory is included in the repository, which is mounted
-> into the devcontainer's home folder for terraform login to store Terraform Cloud tokens into (so
-> they persist across container rebuilds). This directory will contain sensitive information, so do
-> not stop it being gitignored or force any files within to be checked in.
+> Gitignored `.terraform.credentials.d` and `.google.credentials.d` directories are included in the
+> repository, which are mounted into the devcontainer's home folder for `terraform login`/`gcloud
+> login` to store credentials into (so they persist across container rebuilds). These directories
+> will contain sensitive information, so do not stop them being gitignored or force any files within
+> to be checked in.

--- a/terraform/meta/README.md
+++ b/terraform/meta/README.md
@@ -7,6 +7,7 @@ This module sets up the following resources:
 - A Terraform Cloud project
 - A set of Terraform Cloud workspaces (per environment), with appropriate environment-specific
   variables (based on `environments` set variable)
+- A set of GCP projects (per environment)
 
 ## Applying this module
 This module uses Terraform Cloud for remote state storage, but is intended to be run *locally* by a
@@ -14,6 +15,9 @@ user with "interactive" end-user access to both Terraform Cloud and Google Cloud
 not have a chicken-and-egg problem around having to manually create service accounts to manage
 meta-resources like service accounts or projects).
 
-### Authentication
+### Authentication & configuration
 Before you can use this module, you must:
-- use `tf login` to authenticate to Terraform Cloud
+- use `terraform login` to authenticate to Terraform Cloud
+- use `gcloud auth application-default login` to authenticate to GCP
+- specify values for `google_cloud_folder` and `google_cloud_billing_account` as parameters to
+  `terraform` or through a (gitignored) `local.auto.tfvars` file

--- a/terraform/meta/variables.tf
+++ b/terraform/meta/variables.tf
@@ -1,5 +1,20 @@
 variable "environments" {
-  type        = set(string)
+  type        = map(string)
   description = "Names of environments to create resource sets for"
-  default     = ["dev", "integration", "staging", "production"]
+  default = {
+    dev         = "Development"
+    integration = "Integration"
+    staging     = "Staging"
+    production  = "Production"
+  }
+}
+
+variable "google_cloud_folder" {
+  type        = string
+  description = "The ID of the Google Cloud folder to create projects under"
+}
+
+variable "google_cloud_billing_account" {
+  type        = string
+  description = "The ID of the Google Cloud billing account to associate projects with"
 }


### PR DESCRIPTION
- Add Google provider to `meta` module
- Add GCP project resources per environment to `meta` module
- Enable Cloud Resource Manager APIs on all projects
- Add ability for `gcloud` CLI credentials to persist across devcontainer rebuilds

Note: GCP projects have already been created manually previously and the existing projects have been imported into the `meta` workspace state.