### PR TITLE
Fix CI for new multi-module repo

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,10 +49,28 @@ jobs:
           fi
 
       - name: terraform init
-        run: terraform init -backend=false
+        run: |
+          STEP_EXIT_STATUS=0
+          for d in terraform/*; do
+            echo "$d"
+            cd "$d"
+            if ! terraform init -backend=false; then STEP_EXIT_STATUS=1; fi
+            cd "$OLDPWD"
+            echo -e '\n-------------------------\n'
+          done
+          exit $STEP_EXIT_STATUS
 
       - name: terraform validate
-        run: terraform validate
+        run: |
+          STEP_EXIT_STATUS=0
+          for d in terraform/*; do
+            echo "$d"
+            cd "$d"
+            if ! terraform validate; then STEP_EXIT_STATUS=1; fi
+            cd "$OLDPWD"
+            echo -e '\n-------------------------\n'
+          done
+          exit $STEP_EXIT_STATUS
 
       - name: tflint
         run: |


### PR DESCRIPTION
This ensures `terraform init` and `terraform validate` are run across all the modules in this repository.