### PR TITLE
Set up GCP WI pool and ID provider for TF Cloud

### DIFF
--- a/terraform/meta/main.tf
+++ b/terraform/meta/main.tf
@@ -21,7 +21,7 @@ terraform {
 }
 
 provider "tfe" {
-  organization = "govuk"
+  organization = var.tfc_organization_name
 }
 
 provider "google" {
@@ -117,4 +117,47 @@ resource "tfe_variable" "gcp_project_id" {
   key       = "gcp_project_id"
   value     = google_project.environment_project[each.key].id
   sensitive = false
+}
+
+# Set up Workload Identity Federation between Terraform Cloud and GCP
+# see https://github.com/hashicorp/terraform-dynamic-credentials-setup-examples
+resource "google_iam_workload_identity_pool" "tfc_pool" {
+  for_each = var.environments
+
+  project                   = google_project.environment_project[each.key].project_id
+  workload_identity_pool_id = "terraform-cloud-pool"
+
+  display_name = "Terraform Cloud ID Pool"
+  description  = "Pool to enable access to project resources for Terraform Cloud"
+}
+
+resource "google_iam_workload_identity_pool_provider" "tfc_provider" {
+  for_each = var.environments
+
+  project                            = google_project.environment_project[each.key].project_id
+  workload_identity_pool_id          = google_iam_workload_identity_pool.tfc_pool[each.key].workload_identity_pool_id
+  workload_identity_pool_provider_id = "terraform-cloud-provider"
+
+  display_name = "Terraform Cloud ID Provider"
+  description  = "Configures Terraform Cloud as an external identity provider for this project"
+
+  attribute_mapping = {
+    "google.subject"                        = "assertion.sub",
+    "attribute.aud"                         = "assertion.aud",
+    "attribute.terraform_run_phase"         = "assertion.terraform_run_phase",
+    "attribute.terraform_project_id"        = "assertion.terraform_project_id",
+    "attribute.terraform_project_name"      = "assertion.terraform_project_name",
+    "attribute.terraform_workspace_id"      = "assertion.terraform_workspace_id",
+    "attribute.terraform_workspace_name"    = "assertion.terraform_workspace_name",
+    "attribute.terraform_organization_id"   = "assertion.terraform_organization_id",
+    "attribute.terraform_organization_name" = "assertion.terraform_organization_name",
+    "attribute.terraform_run_id"            = "assertion.terraform_run_id",
+    "attribute.terraform_full_workspace"    = "assertion.terraform_full_workspace",
+  }
+
+  oidc {
+    issuer_uri = "https://${var.tfc_hostname}"
+  }
+
+  attribute_condition = "assertion.sub.startsWith(\"organization:${var.tfc_organization_name}:project:${tfe_project.project.name}:workspace:${tfe_workspace.environment_workspace[each.key].name}\")"
 }

--- a/terraform/meta/variables.tf
+++ b/terraform/meta/variables.tf
@@ -18,3 +18,15 @@ variable "google_cloud_billing_account" {
   type        = string
   description = "The ID of the Google Cloud billing account to associate projects with"
 }
+
+variable "tfc_hostname" {
+  type        = string
+  description = "The hostname of the Terraform Cloud/Enterprise instance to use"
+  default     = "app.terraform.io"
+}
+
+variable "tfc_organization_name" {
+  type        = string
+  description = "The name of the Terraform Cloud/Enterprise organization to use"
+  default     = "govuk"
+}


### PR DESCRIPTION
- Set up a GCP Workload Identity Pool for each environment project
- Configure an ID provider for Terraform Cloud within each pool