### PR TITLE
Associate AWS ID variable sets with TFC workspaces

### DIFF
--- a/terraform/meta/variables.tf
+++ b/terraform/meta/variables.tf
@@ -9,6 +9,12 @@ variable "environments" {
   }
 }
 
+variable "local_only_environments" {
+  type        = set(string)
+  description = "A subset of keys from `environments` that represent environments that don't have an API service running on Kubernetes. These will not have AWS resources created for them."
+  default     = ["dev"]
+}
+
 variable "google_cloud_folder" {
   type        = string
   description = "The ID of the Google Cloud folder to create projects under"


### PR DESCRIPTION
This allows the environment workspaces to use identity federation to access AWS resources (specifically, they will need to create Secrets Manager secrets).

- Introduce the concept of "local-only" environments that don't have an API service running on Kubernetes and thus don't need AWS resources created for them
- Access existing AWS identity configuration variable sets and bind them to the environment workspaces (except ones that are "local-only")