### PR TITLE
Reconfigure TF Cloud workspaces

### DIFF
--- a/terraform/discovery_engine/main.tf
+++ b/terraform/discovery_engine/main.tf
@@ -2,7 +2,10 @@ terraform {
   cloud {
     organization = "govuk"
     workspaces {
-      name = "search-v2-infrastructure-integration"
+      project = "govuk-search-api-v2"
+
+      # All workspaces that relate to deployable environments have this tag set up in `meta` module
+      tags = ["search-api-v2-discovery-engine"]
     }
   }
 
@@ -31,11 +34,4 @@ provider "google" {
 
 provider "aws" {
   region = "eu-west-1"
-}
-
-# Allows managing project properties through Terraform
-resource "google_project_service" "cloudresourcemanager" {
-  project                    = var.gcp_project_id
-  service                    = "cloudresourcemanager.googleapis.com"
-  disable_dependent_services = true
 }

--- a/terraform/discovery_engine/service_accounts.tf
+++ b/terraform/discovery_engine/service_accounts.tf
@@ -1,13 +1,5 @@
 # Creates and configures service accounts, IAM roles, role bindings, and keys for `search-api-v2` to
 # be able to access the Discovery Engine API.
-
-# Allows managing IAM programmatically
-resource "google_project_service" "iam" {
-  project                    = var.gcp_project_id
-  service                    = "iam.googleapis.com"
-  disable_dependent_services = true
-}
-
 resource "google_service_account" "api_read" {
   depends_on   = [google_project_service.iam]
   account_id   = "search-api-v2-read"


### PR DESCRIPTION
- Rename TF Cloud workspaces to have `discovery-engine` in the name (as that is the module they are running)
- Remove superfluous IAM and CRM API enablement from `discovery_engine` module (this is set up for the GCP projects in the `meta` module now)
- Tag all `discovery_engine` workspaces with a specific tag (so the module can use it through Terraform Cloud)
- Set `discovery_engine` module cloud workspace to be based on project+tag rather than name (as there is now one workspace per environment)