### PR TITLE
Remove unneeded IAM dependency

### DIFF
--- a/terraform/discovery_engine/service_accounts.tf
+++ b/terraform/discovery_engine/service_accounts.tf
@@ -1,21 +1,18 @@
 # Creates and configures service accounts, IAM roles, role bindings, and keys for `search-api-v2` to
 # be able to access the Discovery Engine API.
 resource "google_service_account" "api_read" {
-  depends_on   = [google_project_service.iam]
   account_id   = "search-api-v2-read"
   display_name = "search-api-v2 (Rails API app; read only)"
   description  = "Read-only service account to provide access to the search-api-v2 Rails app"
 }
 
 resource "google_service_account" "api_write" {
-  depends_on   = [google_project_service.iam]
   account_id   = "search-api-v2-write"
   display_name = "search-api-v2 (Document Sync Worker; write only)"
   description  = "Write-only service account to provide access to the search-api-v2 Document Sync Worker"
 }
 
 resource "google_project_iam_custom_role" "api_read" {
-  depends_on  = [google_project_service.iam]
   role_id     = "search_api_v2_read"
   title       = "search-api-v2 (read only)"
   description = "Enables read-only access to the search-api-v2 Rails app"
@@ -26,7 +23,6 @@ resource "google_project_iam_custom_role" "api_read" {
 }
 
 resource "google_project_iam_custom_role" "api_write" {
-  depends_on  = [google_project_service.iam]
   role_id     = "search_api_v2_write"
   title       = "search-api-v2 (write only)"
   description = "Enabled write-only access to the search-api-v2 Document Sync Worker"


### PR DESCRIPTION
This is now configured in the `meta` module and no longer exists.