### PR TITLE
Configure `generate_google_keys` variable for workspaces

### DIFF
--- a/terraform/meta/main.tf
+++ b/terraform/meta/main.tf
@@ -152,6 +152,19 @@ resource "tfe_variable" "gcp_project_id" {
   sensitive = false
 }
 
+resource "tfe_variable" "generate_google_keys" {
+  for_each = var.environments
+
+  workspace_id = tfe_workspace.discovery_engine_workspace[each.key].id
+  category     = "terraform"
+  description  = "Whether to provision Google keys and AWS secrets in this environment"
+
+  key       = "generate_google_keys"
+  value     = contains(var.local_only_environments, each.key) ? "false" : "true"
+  hcl       = true
+  sensitive = false
+}
+
 # Set up Workload Identity Federation between Terraform Cloud and GCP
 # see https://github.com/hashicorp/terraform-dynamic-credentials-setup-examples
 resource "google_iam_workload_identity_pool" "tfc_pool" {


### PR DESCRIPTION
This should be false for local environments (so we don't generate keys and don't create AWS Secrets Manager resources).