### PR TITLE
Change GCP ID provider name (again)

### DIFF
--- a/terraform/meta/modules/environment/main.tf
+++ b/terraform/meta/modules/environment/main.tf
@@ -115,9 +115,9 @@ resource "google_iam_workload_identity_pool" "tfc_pool" {
 resource "google_iam_workload_identity_pool_provider" "tfc_provider" {
   project                            = google_project.environment_project.project_id
   workload_identity_pool_id          = google_iam_workload_identity_pool.tfc_pool.workload_identity_pool_id
-  workload_identity_pool_provider_id = "terraform-cloud-oidc-provider"
+  workload_identity_pool_provider_id = "terraform-cloud-provider-oidc"
 
-  display_name = "Terraform Cloud ID Provider"
+  display_name = "Terraform Cloud OIDC Provider"
   description  = "Configures Terraform Cloud as an external identity provider for this project"
 
   attribute_mapping = {


### PR DESCRIPTION
We've been iterating on a few things and the provider wound up soft-deleted again and won't re-create with the same name, unfortunately the easiest option of dealing with this is simply changing the name of the created resource.