### PR TITLE
Force delete AWS SM resources on destroy

### DIFF
--- a/terraform/full_environment/service_accounts.tf
+++ b/terraform/full_environment/service_accounts.tf
@@ -66,11 +66,13 @@ resource "google_service_account_key" "api_write" {
 }
 
 resource "aws_secretsmanager_secret" "key_read" {
-  name = "govuk/search-api-v2/google-key-read"
+  name                    = "govuk/search-api-v2/google-key-read"
+  recovery_window_in_days = 0 # Force delete to allow re-applying immediately after destroying
 }
 
 resource "aws_secretsmanager_secret" "key_write" {
-  name = "govuk/search-api-v2/google-key-write"
+  name                    = "govuk/search-api-v2/google-key-write"
+  recovery_window_in_days = 0 # Force delete to allow re-applying immediately after destroying
 }
 
 resource "aws_secretsmanager_secret_version" "key_read" {


### PR DESCRIPTION
These otherwise have a 30 day soft deletion recovery window by default, which means that running a Terraform destroy followed by an apply would fail due to a naming conflict.