### PR TITLE
Manage all GCP APIs through `meta` module

### DIFF
--- a/terraform/full_environment/discovery_engine.tf
+++ b/terraform/full_environment/discovery_engine.tf
@@ -6,6 +6,7 @@ resource "google_project_service" "discoveryengine" {
   project                    = var.gcp_project_id
   service                    = "discoveryengine.googleapis.com"
   disable_dependent_services = true
+  disable_on_destroy         = false
 }
 
 module "govuk_content_discovery_engine" {

--- a/terraform/meta/modules/environment/main.tf
+++ b/terraform/meta/modules/environment/main.tf
@@ -27,31 +27,11 @@ resource "google_project" "environment_project" {
   }
 }
 
-# Required to be able to manage resources using Terraform in the environment-specific module(s)
-resource "google_project_service" "cloudresourcemanager_service" {
-  project                    = google_project.environment_project.project_id
-  service                    = "cloudresourcemanager.googleapis.com"
-  disable_dependent_services = true
-}
+resource "google_project_service" "api_service" {
+  for_each = var.google_cloud_apis
 
-# Required to set up service accounts and manage dynamic credentials
-resource "google_project_service" "iam_service" {
   project                    = google_project.environment_project.project_id
-  service                    = "iam.googleapis.com"
-  disable_dependent_services = true
-}
-
-# Required to manage dynamic credentials
-resource "google_project_service" "iamcredentials_service" {
-  project                    = google_project.environment_project.project_id
-  service                    = "iamcredentials.googleapis.com"
-  disable_dependent_services = true
-}
-
-# Required to manage dynamic credentials
-resource "google_project_service" "sts_service" {
-  project                    = google_project.environment_project.project_id
-  service                    = "sts.googleapis.com"
+  service                    = each.value
   disable_dependent_services = true
 }
 

--- a/terraform/meta/modules/environment/variables.tf
+++ b/terraform/meta/modules/environment/variables.tf
@@ -29,6 +29,21 @@ variable "google_cloud_billing_account" {
   description = "The ID of the Google Cloud billing account to associate projects with"
 }
 
+variable "google_cloud_apis" {
+  type        = set(string)
+  description = "The Google Cloud APIs to enable for the project"
+  default = [
+    # Required to be able to manage resources using Terraform
+    "cloudresourcemanager.googleapis.com",
+    # Required to set up service accounts and manage dynamic credentials
+    "iam.googleapis.com",
+    "iamcredentials.googleapis.com",
+    "sts.googleapis.com",
+    # Required for Discovery Engine
+    "discoveryengine.googleapis.com",
+  ]
+}
+
 variable "tfc_project" {
   type = object({
     id   = string


### PR DESCRIPTION
These are common to all projects, won't change a lot, and make more sense to manage in the `meta` module.

- Add `google_cloud_apis` variable to define set of APIs to enable on all projects
- Use `for_each` to enable GCP APIs
- Set `discoveryengine` API to not disable itself on destroy in `full_environment` module (in preparation for removing it in subsequent commit)