### PR TITLE
Add outputs for Discovery Engine paths

### DIFF
--- a/terraform/full_environment/outputs.tf
+++ b/terraform/full_environment/outputs.tf
@@ -1,0 +1,9 @@
+output "google_cloud_discovery_engine_datastore_path" {
+  description = "The full path of the datastore created by the module (for data ingestion)"
+  value       = module.govuk_content_discovery_engine.datastore_path
+}
+
+output "google_cloud_discovery_engine_engine_path" {
+  description = "The full path of the engine created by the module (for querying)"
+  value       = module.govuk_content_discovery_engine.engine_path
+}

--- a/terraform/modules/google_discovery_engine_restapi/outputs.tf
+++ b/terraform/modules/google_discovery_engine_restapi/outputs.tf
@@ -1,0 +1,13 @@
+output "datastore_path" {
+  description = "The full path of the datastore created by the module (for data ingestion)"
+  value       = restapi_object.discovery_engine_datastore.api_data["name"]
+}
+
+output "engine_path" {
+  description = "The full path of the engine created by the module (for querying)"
+  # TODO: This is currently the same as datastore_path as the API doesn't support creating engines
+  # yet. However, once it does, this can be updated accordingly and the API will be able to use the
+  # engine instead (as the API for querying will continue to be a `servingConfig` nested underneath
+  # this endpoint, only the endpoint itself changes)
+  value = restapi_object.discovery_engine_datastore.api_data["name"]
+}


### PR DESCRIPTION
This adds outputs to the Discovery Engine shared module and the `full_environment` module to reflect the paths on GCP on which the created engine is available.