### PR TITLE
Disable auto-apply in staging and prod TFC

### DIFF
--- a/terraform/meta/main.tf
+++ b/terraform/meta/main.tf
@@ -54,6 +54,7 @@ module "environment_dev" {
   name                        = "dev"
   display_name                = "Development"
   has_deployed_service_in_aws = false
+  auto_apply                  = true
   terraform_module            = "dev_environment"
 }
 
@@ -68,6 +69,7 @@ module "environment_integration" {
   name                        = "integration"
   display_name                = "Integration"
   has_deployed_service_in_aws = true
+  auto_apply                  = true
   terraform_module            = "full_environment"
 }
 

--- a/terraform/meta/modules/environment/main.tf
+++ b/terraform/meta/modules/environment/main.tf
@@ -51,7 +51,7 @@ resource "tfe_workspace" "environment_workspace" {
 
   execution_mode    = "remote"
   working_directory = "terraform/${var.terraform_module}"
-  auto_apply        = true
+  auto_apply        = var.auto_apply
 
   file_triggers_enabled = true
   trigger_patterns = [

--- a/terraform/meta/modules/environment/variables.tf
+++ b/terraform/meta/modules/environment/variables.tf
@@ -14,6 +14,12 @@ variable "has_deployed_service_in_aws" {
   default     = true
 }
 
+variable "auto_apply" {
+  type        = bool
+  description = "Whether to automatically apply changes to this environment through Terraform Cloud"
+  default     = false
+}
+
 variable "terraform_module" {
   type        = string
   description = "The name of the Terraform module for this environment (used as working directory)"


### PR DESCRIPTION
We're about to start working on the events data integration and want to let it bed in in integration first before moving on to deploy it fully. Once this is done, we can figure out what our long-term auto-apply strategy is.