### PR TITLE
Datastore schema: disallow additional properties

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,6 @@
 name: Terraform validation and linting
 on:
   push:
-    paths: ["**/*.tf", "**/*.hcl", ".github/workflows/lint.yml"]
 env:
   TF_PLUGIN_CACHE_DIR: ${{ github.workspace }}/.terraform.d/plugin-cache
   TFLINT_VERSION: v0.48.0

--- a/terraform/modules/google_discovery_engine_restapi/files/datastore_schema.json
+++ b/terraform/modules/google_discovery_engine_restapi/files/datastore_schema.json
@@ -120,5 +120,6 @@
     "url",
     "public_timestamp",
     "document_type"
-  ]
+  ],
+  "additionalProperties": false
 }


### PR DESCRIPTION
This updates the schema to reflect that no additional properties should be present in any JSON documents above and beyond those explicitly specified in the schema.

Also updates Github lint workflow to always run even when no relevant
files have been changed (as this is now a required workflow for branch
protection purposes).