### PR TITLE
Add simple validation for JSON schema

### DIFF
--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -1,0 +1,15 @@
+name: Validate datastore JSON Schema
+on:
+  push:
+jobs:
+  validate-json-schema:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.11
+      - name: Install dependencies
+        run: pipx install check-jsonschema
+      - name: Validate datastore JSON Schema against metaschema
+        run: check-jsonschema --check-metaschema terraform/modules/google_discovery_engine_restapi/files/datastore_schema.json


### PR DESCRIPTION
This validates the JSON schema for the Google Discovery Engine datastore against the JSON Schema metaschema to make sure it is valid.