### PR TITLE
Tweak datastore schema

### DIFF
--- a/terraform/modules/google_discovery_engine_restapi/files/datastore_schema.json
+++ b/terraform/modules/google_discovery_engine_restapi/files/datastore_schema.json
@@ -87,7 +87,10 @@
     },
     "parts": {
       "description": "A list of parts (shown below search result if present)",
-      "type": "array",
+      "type": [
+        "array",
+        "null"
+      ],
       "items": {
         "type": "object",
         "properties": {
@@ -108,7 +111,8 @@
         },
         "required": [
           "title",
-          "slug"
+          "slug",
+          "body"
         ],
         "additionalProperties": false
       }


### PR DESCRIPTION
- Allow `parts` to be nullable
- Require `parts.body` to be non-null (it may be an empty string but not null)