### PR TITLE
Do not make parts nullable

### DIFF
--- a/terraform/modules/google_discovery_engine_restapi/files/datastore_schema.json
+++ b/terraform/modules/google_discovery_engine_restapi/files/datastore_schema.json
@@ -92,10 +92,7 @@
     },
     "parts": {
       "description": "A list of parts (shown below search result if present)",
-      "type": [
-        "array",
-        "null"
-      ],
+      "type": "array",
       "items": {
         "type": "object",
         "properties": {


### PR DESCRIPTION
We've updated the sync worker to not send through null fields anyway, and Discovery Engine does not support multi-type field syntax.