### PR TITLE
Move to single API key and SA for API

### DIFF
--- a/terraform/full_environment/service_accounts.tf
+++ b/terraform/full_environment/service_accounts.tf
@@ -1,15 +1,9 @@
 # Creates and configures service accounts, IAM roles, role bindings, and keys for `search-api-v2` to
 # be able to access the Discovery Engine API.
-resource "google_service_account" "api_read" {
+resource "google_service_account" "api" {
   account_id   = "search-api-v2-read"
-  display_name = "search-api-v2 (Rails API app; read only)"
-  description  = "Read-only service account to provide access to the search-api-v2 Rails app"
-}
-
-resource "google_service_account" "api_write" {
-  account_id   = "search-api-v2-write"
-  display_name = "search-api-v2 (Document Sync Worker; write only)"
-  description  = "Write-only service account to provide access to the search-api-v2 Document Sync Worker"
+  display_name = "search-api-v2 (Rails API app and document sync worker)"
+  description  = "Service account to provide access to the search-api-v2 Rails app and document sync worker"
 }
 
 resource "google_project_iam_custom_role" "api_read" {
@@ -44,7 +38,7 @@ resource "google_project_iam_binding" "api_read" {
   role    = google_project_iam_custom_role.api_read.id
 
   members = [
-    google_service_account.api_read.member
+    google_service_account.api.member
   ]
 }
 
@@ -53,38 +47,22 @@ resource "google_project_iam_binding" "api_write" {
   role    = google_project_iam_custom_role.api_write.id
 
   members = [
-    google_service_account.api_write.member
+    google_service_account.api.member
   ]
 }
 
-resource "google_service_account_key" "api_read" {
-  service_account_id = google_service_account.api_read.id
+resource "google_service_account_key" "api" {
+  service_account_id = google_service_account.api.id
 }
 
-resource "google_service_account_key" "api_write" {
-  service_account_id = google_service_account.api_write.id
-}
-
-resource "aws_secretsmanager_secret" "key_read" {
-  name                    = "govuk/search-api-v2/google-key-read"
+resource "aws_secretsmanager_secret" "key" {
+  name                    = "govuk/search-api-v2/google-cloud-credentials"
   recovery_window_in_days = 0 # Force delete to allow re-applying immediately after destroying
 }
 
-resource "aws_secretsmanager_secret" "key_write" {
-  name                    = "govuk/search-api-v2/google-key-write"
-  recovery_window_in_days = 0 # Force delete to allow re-applying immediately after destroying
-}
-
-resource "aws_secretsmanager_secret_version" "key_read" {
-  secret_id = aws_secretsmanager_secret.key_read.id
+resource "aws_secretsmanager_secret_version" "key" {
+  secret_id = aws_secretsmanager_secret.key.id
   secret_string = jsonencode({
-    "credentials.json" = base64decode(google_service_account_key.api_read.private_key)
-  })
-}
-
-resource "aws_secretsmanager_secret_version" "key_write" {
-  secret_id = aws_secretsmanager_secret.key_write.id
-  secret_string = jsonencode({
-    "credentials.json" = base64decode(google_service_account_key.api_write.private_key)
+    "credentials.json" = base64decode(google_service_account_key.api.private_key)
   })
 }


### PR DESCRIPTION
This will stay a monolithic single app with worker for now, so there is no point separating the two service accounts. We may split them out again in the future, so keep the two roles but assign them to the same SA.