### PR TITLE
Add Discovery Engine configuration to AWS SM

### DIFF
--- a/terraform/full_environment/discovery_engine.tf
+++ b/terraform/full_environment/discovery_engine.tf
@@ -6,3 +6,16 @@ module "govuk_content_discovery_engine" {
 
   engine_id = "govuk_content"
 }
+
+resource "aws_secretsmanager_secret" "discovery_engine_configuration" {
+  name                    = "govuk/search-api-v2/google-cloud-credentials"
+  recovery_window_in_days = 0 # Force delete to allow re-applying immediately after destroying
+}
+
+resource "aws_secretsmanager_secret_version" "discovery_engine_configuration" {
+  secret_id = aws_secretsmanager_secret.key.id
+  secret_string = jsonencode({
+    "DISCOVERY_ENGINE_DATASTORE" = module.govuk_content_discovery_engine.datastore_path,
+    "DISCOVERY_ENGINE_ENGINE"    = module.govuk_content_discovery_engine.engine_path,
+  })
+}


### PR DESCRIPTION
This adds the paths for datastore and engine to an AWS Secrets Manager secret, for picking up by the Kubernetes platform.