### PR TITLE
Service account to read analytics data

### DIFF
--- a/terraform/full_environment/service_accounts.tf
+++ b/terraform/full_environment/service_accounts.tf
@@ -66,3 +66,9 @@ resource "aws_secretsmanager_secret_version" "key" {
     "credentials.json" = base64decode(google_service_account_key.api.private_key)
   })
 }
+
+resource "google_service_account" "analytics_events_pipeline" {
+  account_id   = "analytics-events-pipeline"
+  display_name = "analytics-events-pipeline"
+  description  = "Service account for reading GA4 search events data and importing events into our project"
+}


### PR DESCRIPTION
Service account added for GA Analytics team to provide read permissions for search events data