### PR TITLE
Export serving config path instead of engine

### DIFF
--- a/terraform/full_environment/discovery_engine.tf
+++ b/terraform/full_environment/discovery_engine.tf
@@ -15,7 +15,7 @@ resource "aws_secretsmanager_secret" "discovery_engine_configuration" {
 resource "aws_secretsmanager_secret_version" "discovery_engine_configuration" {
   secret_id = aws_secretsmanager_secret.discovery_engine_configuration.id
   secret_string = jsonencode({
-    "DISCOVERY_ENGINE_DATASTORE" = module.govuk_content_discovery_engine.datastore_path,
-    "DISCOVERY_ENGINE_ENGINE"    = module.govuk_content_discovery_engine.engine_path,
+    "DISCOVERY_ENGINE_DATASTORE"      = module.govuk_content_discovery_engine.datastore_path,
+    "DISCOVERY_ENGINE_SERVING_CONFIG" = module.govuk_content_discovery_engine.serving_config_path,
   })
 }

--- a/terraform/full_environment/outputs.tf
+++ b/terraform/full_environment/outputs.tf
@@ -3,7 +3,7 @@ output "google_cloud_discovery_engine_datastore_path" {
   value       = module.govuk_content_discovery_engine.datastore_path
 }
 
-output "google_cloud_discovery_engine_engine_path" {
-  description = "The full path of the engine created by the module (for querying)"
-  value       = module.govuk_content_discovery_engine.engine_path
+output "google_cloud_discovery_engine_serving_config_path" {
+  description = "The full path of the default serving config on the engine created by the module (for querying)"
+  value       = module.govuk_content_discovery_engine.serving_config_path
 }

--- a/terraform/modules/google_discovery_engine_restapi/outputs.tf
+++ b/terraform/modules/google_discovery_engine_restapi/outputs.tf
@@ -3,11 +3,10 @@ output "datastore_path" {
   value       = restapi_object.discovery_engine_datastore.api_data["name"]
 }
 
-output "engine_path" {
-  description = "The full path of the engine created by the module (for querying)"
-  # TODO: This is currently the same as datastore_path as the API doesn't support creating engines
-  # yet. However, once it does, this can be updated accordingly and the API will be able to use the
-  # engine instead (as the API for querying will continue to be a `servingConfig` nested underneath
-  # this endpoint, only the endpoint itself changes)
-  value = restapi_object.discovery_engine_datastore.api_data["name"]
+output "serving_config_path" {
+  description = "The serving config for the engine created by the module (for querying)"
+  # TODO: This is currently defined through the datastore path as the API doesn't support creating
+  # engines yet. However, once it does, this can be updated accordingly and the API will be able to
+  # use a servingConfig on the engine instead.
+  value = "${restapi_object.discovery_engine_datastore.api_data["name"]}/servingConfigs/default_serving_config"
 }


### PR DESCRIPTION
This is what we will be using in the API app, so might as well use this instead of the app having to build the path itself.