### PR TITLE
Block until async completes fix

### DIFF
--- a/terraform/full_environment/files/analytics_transfer_function/main.py
+++ b/terraform/full_environment/files/analytics_transfer_function/main.py
@@ -1,6 +1,5 @@
 ### TO DO
 ### Docstring
-### WILL empty pageCategories field cause issues?
 ### Add time partitioning and time argument features
 ### Add logic to evaluate whether the query has been successful
 import functions_framework
@@ -35,6 +34,11 @@ def function_analytics_events_transfer(request):
 
 
         ''')
-    bq_location = os.environ.get("BQ_LOCATION")
-    as_completed(client.query(QUERY, location=bq_location))
-    return 'Success'
+
+    try:
+        bq_location = os.environ.get("BQ_LOCATION")
+        job = client.query(QUERY, location=bq_location)
+        output = job.result()
+        return 'Success'
+    except Exception as e:
+        raise(e)

--- a/terraform/full_environment/files/analytics_transfer_function/main.py
+++ b/terraform/full_environment/files/analytics_transfer_function/main.py
@@ -9,7 +9,6 @@ def function_analytics_events_transfer(request):
     """
     from google.cloud import bigquery
     import os
-    from concurrent.futures import as_completed
     env_project_name = os.environ.get("PROJECT_NAME")
     env_dataset_name = os.environ.get("DATASET_NAME")
     env_analytics_project_name = os.environ.get("ANALYTICS_PROJECT_NAME")


### PR DESCRIPTION
Function was returning success before the async BQ job had finished / we knew it had run successfully.

.result() method blocks until async job is complete 