### PR TITLE
Migrate to Discovery Engine engines

### DIFF
--- a/terraform/dev_environment/main.tf
+++ b/terraform/dev_environment/main.tf
@@ -55,5 +55,6 @@ module "engine" {
   source   = "../modules/google_discovery_engine_restapi"
   for_each = var.engines
 
-  engine_id = each.key
+  datastore_id = each.key
+  engine_id    = each.key
 }

--- a/terraform/full_environment/discovery_engine.tf
+++ b/terraform/full_environment/discovery_engine.tf
@@ -4,7 +4,8 @@
 module "govuk_content_discovery_engine" {
   source = "../modules/google_discovery_engine_restapi"
 
-  engine_id = "govuk_content"
+  datastore_id = "govuk_content"
+  engine_id    = "govuk"
 }
 
 resource "aws_secretsmanager_secret" "discovery_engine_configuration" {

--- a/terraform/modules/google_discovery_engine_restapi/outputs.tf
+++ b/terraform/modules/google_discovery_engine_restapi/outputs.tf
@@ -5,8 +5,5 @@ output "datastore_path" {
 
 output "serving_config_path" {
   description = "The serving config for the engine created by the module (for querying)"
-  # TODO: This is currently defined through the datastore path as the API doesn't support creating
-  # engines yet. However, once it does, this can be updated accordingly and the API will be able to
-  # use a servingConfig on the engine instead.
-  value = "${restapi_object.discovery_engine_datastore.api_data["name"]}/servingConfigs/default_serving_config"
+  value       = "${restapi_object.discovery_engine_engine.api_data["name"]}/servingConfigs/default_serving_config"
 }

--- a/terraform/modules/google_discovery_engine_restapi/variables.tf
+++ b/terraform/modules/google_discovery_engine_restapi/variables.tf
@@ -1,10 +1,15 @@
-variable "engine_id" {
-  description = "The name of the engine and datastore to create"
+variable "datastore_id" {
+  description = "The name of the datastore to create"
   type        = string
 }
 
-variable "tier" {
+variable "engine_id" {
+  description = "The name of the engine to create"
+  type        = string
+}
+
+variable "search_tier" {
   type        = string
   description = "The tier of the Discovery Engine to use, e.g. STANDARD or ENTERPRISE"
-  default     = "STANDARD"
+  default     = "SEARCH_TIER_STANDARD"
 }


### PR DESCRIPTION
Now that the Discovery Engine API supports creating engines, we need to migrate over to using engines instead of datastores directly.

- Make engine and datastore names configurable separately
- Create engine in `discovery_engine` module
- Move engine-related configuration out of datastore
- Change serving config output to be nested under the engine instead of the datastore
- Configure engine name in dev and full environments