### PR TITLE
Export datastore default branch into AWS SM

### DIFF
--- a/terraform/full_environment/discovery_engine.tf
+++ b/terraform/full_environment/discovery_engine.tf
@@ -16,7 +16,8 @@ resource "aws_secretsmanager_secret" "discovery_engine_configuration" {
 resource "aws_secretsmanager_secret_version" "discovery_engine_configuration" {
   secret_id = aws_secretsmanager_secret.discovery_engine_configuration.id
   secret_string = jsonencode({
-    "DISCOVERY_ENGINE_DATASTORE"      = module.govuk_content_discovery_engine.datastore_path,
-    "DISCOVERY_ENGINE_SERVING_CONFIG" = module.govuk_content_discovery_engine.serving_config_path,
+    "DISCOVERY_ENGINE_DATASTORE_BRANCH" = module.govuk_content_discovery_engine.datastore_default_branch_path,
+    "DISCOVERY_ENGINE_DATASTORE"        = module.govuk_content_discovery_engine.datastore_path,
+    "DISCOVERY_ENGINE_SERVING_CONFIG"   = module.govuk_content_discovery_engine.serving_config_path,
   })
 }

--- a/terraform/modules/google_discovery_engine_restapi/outputs.tf
+++ b/terraform/modules/google_discovery_engine_restapi/outputs.tf
@@ -3,6 +3,11 @@ output "datastore_path" {
   value       = restapi_object.discovery_engine_datastore.api_data["name"]
 }
 
+output "datastore_default_branch_path" {
+  description = "The full path of the default branch of the datastore created by the module (for data ingestion)"
+  value       = "${restapi_object.discovery_engine_datastore.api_data["name"]}/branches/default_branch"
+}
+
 output "serving_config_path" {
   description = "The serving config for the engine created by the module (for querying)"
   value       = "${restapi_object.discovery_engine_engine.api_data["name"]}/servingConfigs/default_serving_config"


### PR DESCRIPTION
This will allow us to have the app talk to the branch without having to manually construct the branch path in the app.