### PR TITLE
Add `full_environment_without_events` environment module

### DIFF
--- a/terraform/full_environment_without_events/README.md
+++ b/terraform/full_environment_without_events/README.md
@@ -1,0 +1,7 @@
+# full_environment_without_events
+This is a temporary module that copies or symlinks the more stable, non-event related resources from
+the `full_environment` module. This allows us to aggressively iterate on the events ingestion code
+but only have it deploy to a single (integration) environment.
+
+TODO: This environment should be deleted and staging/prod should consume the main environment as
+soon as events ingestion code is stable.

--- a/terraform/full_environment_without_events/discovery_engine.tf
+++ b/terraform/full_environment_without_events/discovery_engine.tf
@@ -1,0 +1,1 @@
+../full_environment/discovery_engine.tf

--- a/terraform/full_environment_without_events/main.tf
+++ b/terraform/full_environment_without_events/main.tf
@@ -1,0 +1,60 @@
+terraform {
+  cloud {
+    organization = "govuk"
+    workspaces {
+      project = "govuk-search-api-v2"
+
+      # All workspaces for this module have this tag set up by `meta` module
+      tags = ["search-api-v2-full_environmen_without_events"]
+    }
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.21.0"
+    }
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.1.0"
+    }
+    restapi = {
+      source  = "Mastercard/restapi"
+      version = "~> 1.18.2"
+    }
+  }
+
+  required_version = "~> 1.6"
+}
+
+provider "google" {
+  project = var.gcp_project_id
+  region  = var.gcp_region
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+# Used to extract access token from the provider so we can call the REST API
+data "google_client_config" "default" {}
+
+# Using REST API provider as a "temporary" workaround, as there are no native Terraform resources
+# for Discovery Engine in the Google provider yet
+provider "restapi" {
+  uri = "https://discoveryengine.googleapis.com/${var.discovery_engine_api_version}/projects/${var.gcp_project_id}/locations/${var.discovery_engine_location}/collections/default_collection"
+
+  # Writes in GCP APIs return an "operation" reference rather than the object being written
+  write_returns_object = false
+
+  # Discovery Engine API uses POST for create, PATCH for update
+  create_method = "POST"
+  update_method = "PATCH"
+
+  headers = {
+    # Piggyback on the the Terraform provider's generated temporary credentials to authenticate
+    # to the API with
+    "Authorization"       = "Bearer ${data.google_client_config.default.access_token}"
+    "X-Goog-User-Project" = var.gcp_project_id
+  }
+}

--- a/terraform/full_environment_without_events/outputs.tf
+++ b/terraform/full_environment_without_events/outputs.tf
@@ -1,0 +1,1 @@
+../full_environment/outputs.tf

--- a/terraform/full_environment_without_events/service_accounts.tf
+++ b/terraform/full_environment_without_events/service_accounts.tf
@@ -1,0 +1,1 @@
+../full_environment/service_accounts.tf

--- a/terraform/full_environment_without_events/variables.tf
+++ b/terraform/full_environment_without_events/variables.tf
@@ -1,0 +1,32 @@
+variable "gcp_project_id" {
+  type        = string
+  description = "GCP Project ID of the project to create infrastructure in, e.g. search-api-v2-integration"
+}
+
+variable "gcp_region" {
+  type        = string
+  description = "GCP region to create non-global infrastructure in, e.g. europe-west2"
+  default     = "europe-west2"
+}
+
+variable "aws_region" {
+  type        = string
+  description = "AWS region to create infrastructure in, e.g. eu-west-1"
+  default     = "eu-west-1"
+}
+
+variable "discovery_engine_api_version" {
+  type        = string
+  description = "The version of the Discovery Engine API to use, e.g. v1alpha"
+  # Defaulting to `v1alpha` as `v1beta` and `v1` APIs don't support datastore creation yet (as of
+  # October 2023)
+  default = "v1alpha"
+}
+
+variable "discovery_engine_location" {
+  type        = string
+  description = "GCP location to create Discovery Engine Datastore instance in, e.g. global"
+  # As of October 2023, we must use `global` as some event-related features are only available
+  # there, but this may change before going live
+  default = "global"
+}

--- a/terraform/meta/main.tf
+++ b/terraform/meta/main.tf
@@ -83,7 +83,7 @@ module "environment_staging" {
   name                        = "staging"
   display_name                = "Staging"
   has_deployed_service_in_aws = true
-  terraform_module            = "full_environment"
+  terraform_module            = "full_environment_without_events"
 }
 
 module "environment_production" {
@@ -96,5 +96,5 @@ module "environment_production" {
   name                        = "production"
   display_name                = "Production"
   has_deployed_service_in_aws = true
-  terraform_module            = "full_environment"
+  terraform_module            = "full_environment_without_events"
 }


### PR DESCRIPTION
This is a temporary module that symlinks or copies the more stable, non-event related resources from the `full_environment` module. This allows us to aggressively iterate on the events ingestion code but only have it deploy to a single (integration) environment.