### PR TITLE
Always auto-apply TFC workspaces

### DIFF
--- a/terraform/meta/main.tf
+++ b/terraform/meta/main.tf
@@ -54,7 +54,6 @@ module "environment_dev" {
   name                        = "dev"
   display_name                = "Development"
   has_deployed_service_in_aws = false
-  auto_apply                  = true
   terraform_module            = "dev_environment"
 }
 
@@ -69,7 +68,6 @@ module "environment_integration" {
   name                        = "integration"
   display_name                = "Integration"
   has_deployed_service_in_aws = true
-  auto_apply                  = true
   terraform_module            = "full_environment"
 }
 

--- a/terraform/meta/modules/environment/main.tf
+++ b/terraform/meta/modules/environment/main.tf
@@ -51,7 +51,7 @@ resource "tfe_workspace" "environment_workspace" {
 
   execution_mode    = "remote"
   working_directory = "terraform/${var.terraform_module}"
-  auto_apply        = var.auto_apply
+  auto_apply        = true
   terraform_version = "~> 1.6.3"
 
   file_triggers_enabled = true

--- a/terraform/meta/modules/environment/variables.tf
+++ b/terraform/meta/modules/environment/variables.tf
@@ -14,12 +14,6 @@ variable "has_deployed_service_in_aws" {
   default     = true
 }
 
-variable "auto_apply" {
-  type        = bool
-  description = "Whether to automatically apply changes to this environment through Terraform Cloud"
-  default     = false
-}
-
 variable "terraform_module" {
   type        = string
   description = "The name of the Terraform module for this environment (used as working directory)"


### PR DESCRIPTION
Now that we have temporarily split the environments into separate `full_environment` and `full_environment_without_events`, we can confidently auto-apply everywhere again #ContinuousDelivery