### PR TITLE
Consolidate Discovery Engine configuration secret

### DIFF
--- a/terraform/full_environment/discovery_engine.tf
+++ b/terraform/full_environment/discovery_engine.tf
@@ -16,6 +16,7 @@ resource "aws_secretsmanager_secret" "discovery_engine_configuration" {
 resource "aws_secretsmanager_secret_version" "discovery_engine_configuration" {
   secret_id = aws_secretsmanager_secret.discovery_engine_configuration.id
   secret_string = jsonencode({
+    "GOOGLE_CLOUD_CREDENTIALS"          = base64decode(google_service_account_key.api.private_key)
     "DISCOVERY_ENGINE_DATASTORE_BRANCH" = module.govuk_content_discovery_engine.datastore_default_branch_path,
     "DISCOVERY_ENGINE_DATASTORE"        = module.govuk_content_discovery_engine.datastore_path,
     "DISCOVERY_ENGINE_SERVING_CONFIG"   = module.govuk_content_discovery_engine.serving_config_path,

--- a/terraform/full_environment/service_accounts.tf
+++ b/terraform/full_environment/service_accounts.tf
@@ -6,6 +6,10 @@ resource "google_service_account" "api" {
   description  = "Service account to provide access to the search-api-v2 Rails app and document sync worker"
 }
 
+resource "google_service_account_key" "api" {
+  service_account_id = google_service_account.api.id
+}
+
 resource "google_project_iam_custom_role" "api_read" {
   role_id     = "search_api_v2_read"
   title       = "search-api-v2 (read only)"
@@ -49,22 +53,6 @@ resource "google_project_iam_binding" "api_write" {
   members = [
     google_service_account.api.member
   ]
-}
-
-resource "google_service_account_key" "api" {
-  service_account_id = google_service_account.api.id
-}
-
-resource "aws_secretsmanager_secret" "key" {
-  name                    = "govuk/search-api-v2/google-cloud-credentials"
-  recovery_window_in_days = 0 # Force delete to allow re-applying immediately after destroying
-}
-
-resource "aws_secretsmanager_secret_version" "key" {
-  secret_id = aws_secretsmanager_secret.key.id
-  secret_string = jsonencode({
-    "credentials.json" = base64decode(google_service_account_key.api.private_key)
-  })
 }
 
 resource "google_service_account" "analytics_events_pipeline" {


### PR DESCRIPTION
- Remove the separate AWS Secrets Manager secret for GCP credentials
- Add the GCP credentials to the existing Discovery Engine configuration secret as `GOOGLE_CLOUD_CREDENTIALS` so the app can pick them up straight from the JSON value in an environment variable