### PR TITLE
Scheduler instances to handle both event types

### DIFF
--- a/terraform/full_environment/events_ingestion.tf
+++ b/terraform/full_environment/events_ingestion.tf
@@ -246,9 +246,9 @@ resource "google_cloudfunctions2_function" "import_user_events_vertex" {
   }
 }
 
-# scheduler resource that will transfer vertex bq data - > vertex datastore at 1230
-resource "google_cloud_scheduler_job" "daily_transfer_bq_to_vertex" {
-  name        = "transfer_vertex_bq_to_vertex_datastore"
+# scheduler resource that will transfer `search` vertex bq data - > vertex datastore at 1230
+resource "google_cloud_scheduler_job" "daily_transfer_bq_search_to_vertex" {
+  name        = "transfer_search_event_to_vertex_datastore"
   description = "transfer search vertex bq data to vertex datastore"
   schedule    = "30 12 * * *"
   time_zone   = "Europe/London"
@@ -256,7 +256,31 @@ resource "google_cloud_scheduler_job" "daily_transfer_bq_to_vertex" {
   http_target {
     http_method = "POST"
     uri         = google_cloudfunctions2_function.import_user_events_vertex.url
-    body        = base64encode("")
+    body        = base64encode("{ \"event_type\" : \"search\"}")
+    headers = {
+      "Content-Type" = "application/json"
+    }
+    oidc_token {
+      service_account_email = google_service_account.trigger_function.email
+      audience              = google_cloudfunctions2_function.import_user_events_vertex.url
+    }
+  }
+}
+
+# scheduler resource that will transfer `view-item` vertex bq data - > vertex datastore at 1230
+resource "google_cloud_scheduler_job" "daily_transfer_bq_view_item_to_vertex" {
+  name        = "transfer_view_item_to_vertex_datastore"
+  description = "transfer view item vertex bq data to vertex datastore"
+  schedule    = "30 12 * * *"
+  time_zone   = "Europe/London"
+
+  http_target {
+    http_method = "POST"
+    uri         = google_cloudfunctions2_function.import_user_events_vertex.url
+    body        = base64encode("{ \"event_type\" : \"view-item\"}")
+    headers = {
+      "Content-Type" = "application/json"
+    }
     oidc_token {
       service_account_email = google_service_account.trigger_function.email
       audience              = google_cloudfunctions2_function.import_user_events_vertex.url

--- a/terraform/full_environment/files/vertex_events_push/main.py
+++ b/terraform/full_environment/files/vertex_events_push/main.py
@@ -11,10 +11,13 @@ def import_user_events_vertex(request):
     '''
     from google.cloud import discoveryengine
 
+    request_json = request.get_json(silent=True)
+    event_type = request_json.get("event_type") # `view-item` or `search`
+
     bq_client = discoveryengine.BigQuerySource(
         project_id = 'search-api-v2-integration', 
         dataset_id= 'analytics_events_vertex', 
-        table_id = 'view-item-event'
+        table_id = f'{event_type}-event'
         )
 
     client = discoveryengine.UserEventServiceClient()


### PR DESCRIPTION
- Python can now query either `view-item-events` or `search-events` table
- Scheduler instances that can trigger ingestion of either of these event types
- 