### PR TITLE
Removed unused field

### DIFF
--- a/terraform/full_environment/files/search-event-schema.json
+++ b/terraform/full_environment/files/search-event-schema.json
@@ -42,10 +42,5 @@
         "mode": "REQUIRED"
       }
     ]
-  },
-  {
-    "name": "pageCategories",
-    "type": "STRING",
-    "mode": "REPEATED"
   }
 ]


### PR DESCRIPTION
Removing `pageCategories` field not present in latest definition of user event from Google 