### PR TITLE
Add BigQuery setup for evaluation tool

### DIFF
--- a/terraform/full_environment/evaluator.tf
+++ b/terraform/full_environment/evaluator.tf
@@ -1,0 +1,43 @@
+resource "google_bigquery_dataset" "evaluator" {
+  dataset_id                 = "search-v2-evaluator"
+  location                   = var.gcp_region
+  delete_contents_on_destroy = true
+}
+
+resource "google_bigquery_table" "evaluator" {
+  dataset_id          = google_bigquery_dataset.evaluator.dataset_id
+  table_id            = "evaluator"
+  schema              = file("./files/evaluator-schema.json")
+  deletion_protection = false
+}
+
+resource "google_service_account" "evaluator" {
+  account_id   = "search-v2-evaluator"
+  display_name = "search-v2-evaluator (Rails app)"
+  description  = "Service account to provide access to BigQuery for the search-v2-evaluator Rails app"
+}
+
+resource "google_service_account_key" "evaluator" {
+  service_account_id = google_service_account.evaluator.id
+}
+
+resource "google_project_iam_custom_role" "evaluator" {
+  role_id     = "evaluator"
+  title       = "search-v2-evaluator"
+  description = "Enables write access to BigQuery for the search-v2-evaluator Rails app"
+
+  permissions = [
+    "bigquery.tables.get",
+    "bigquery.tables.updateData",
+  ]
+}
+
+resource "google_bigquery_table_iam_binding" "evaluator" {
+  dataset_id = google_bigquery_dataset.evaluator.dataset_id
+  table_id   = google_bigquery_table.evaluator.table_id
+  role       = google_project_iam_custom_role.evaluator.role_id
+
+  members = [
+    "serviceAccount:${google_service_account.evaluator.email}",
+  ]
+}

--- a/terraform/full_environment/files/evaluator-schema.json
+++ b/terraform/full_environment/files/evaluator-schema.json
@@ -1,0 +1,59 @@
+[
+  {
+    "name": "query_id",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "anonymised_user_id",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "timestamp",
+    "type": "TIMESTAMP",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "search_query",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "result_ratings",
+    "type": "RECORD",
+    "mode": "REPEATED",
+    "fields": [
+      {
+        "name": "content_id",
+        "type": "STRING",
+        "mode": "REQUIRED"
+      },
+      {
+        "name": "url",
+        "type": "STRING",
+        "mode": "REQUIRED"
+      },
+      {
+        "name": "rating",
+        "type": "INTEGER",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "position",
+        "type": "INTEGER",
+        "mode": "REQUIRED"
+      }
+    ]
+  },
+  {
+    "name": "suggested_url",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "comments",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  }
+]


### PR DESCRIPTION
This adds a BigQuery dataset and table for the evaluation tool to persist feedback to, and a service account, role, and binding to enable it.