### PR TITLE
Make all environments use `full_environment` again

### DIFF
--- a/terraform/meta/main.tf
+++ b/terraform/meta/main.tf
@@ -81,7 +81,7 @@ module "environment_staging" {
   name                        = "staging"
   display_name                = "Staging"
   has_deployed_service_in_aws = true
-  terraform_module            = "full_environment_without_events"
+  terraform_module            = "full_environment"
 }
 
 module "environment_production" {
@@ -94,5 +94,5 @@ module "environment_production" {
   name                        = "production"
   display_name                = "Production"
   has_deployed_service_in_aws = true
-  terraform_module            = "full_environment_without_events"
+  terraform_module            = "full_environment"
 }


### PR DESCRIPTION
The events orchestration code is now ready for prime time. This means we can once again use the same full_environment module for all environments.