### PR TITLE
Output datastore serving config path from DE module

### DIFF
--- a/terraform/modules/google_discovery_engine_restapi/outputs.tf
+++ b/terraform/modules/google_discovery_engine_restapi/outputs.tf
@@ -10,5 +10,7 @@ output "datastore_default_branch_path" {
 
 output "serving_config_path" {
   description = "The serving config for the engine created by the module (for querying)"
-  value       = "${restapi_object.discovery_engine_engine.api_data["name"]}/servingConfigs/default_serving_config"
+  # TODO: Revert to this once Vertex engine bug is fixed
+  # value       = "${restapi_object.discovery_engine_engine.api_data["name"]}/servingConfigs/default_search"
+  value = "${restapi_object.discovery_engine_datastore.api_data["name"]}/servingConfigs/default_search"
 }


### PR DESCRIPTION
Until the bug around being unable to attach serving controls to an engine serving config is fixed, revert to outputting the datastore serving config path from the Discovery Engine module (and change it to point to the search serving config).