### PR TITLE
Add missing BQ permission for eval tool

### DIFF
--- a/terraform/full_environment/evaluator.tf
+++ b/terraform/full_environment/evaluator.tf
@@ -27,6 +27,7 @@ resource "google_project_iam_custom_role" "evaluator" {
   description = "Enables write access to BigQuery for the search-v2-evaluator Rails app"
 
   permissions = [
+    "bigquery.datasets.get",
     "bigquery.tables.get",
     "bigquery.tables.updateData",
   ]


### PR DESCRIPTION
The client library needs to be able to read datasets to access the table.