### PR TITLE
Evaluator: Move to dataset-level IAM binding

### DIFF
--- a/terraform/full_environment/evaluator.tf
+++ b/terraform/full_environment/evaluator.tf
@@ -32,9 +32,8 @@ resource "google_project_iam_custom_role" "evaluator" {
   ]
 }
 
-resource "google_bigquery_table_iam_binding" "evaluator" {
+resource "google_bigquery_dataset_iam_binding" "evaluator" {
   dataset_id = google_bigquery_dataset.evaluator.dataset_id
-  table_id   = google_bigquery_table.evaluator_ratings.table_id
   role       = google_project_iam_custom_role.evaluator.id
 
   members = [


### PR DESCRIPTION
This doesn't need to be on a table-level (and we seem to need dataset access anyway).