### PR TITLE
Add serving config and controls on engine

### DIFF
--- a/terraform/modules/google_discovery_engine_restapi/main.tf
+++ b/terraform/modules/google_discovery_engine_restapi/main.tf
@@ -142,3 +142,67 @@ resource "restapi_object" "discovery_engine_synonym_control" {
     }
   })
 }
+
+resource "restapi_object" "discovery_engine_engine_serving_config" {
+  depends_on = [
+    restapi_object.discovery_engine_engine_boost_control,
+    restapi_object.discovery_engine_engine_synonym_control
+  ]
+  path      = "/engines/${restapi_object.discovery_engine_engine.object_id}/servingConfigs/default_search?updateMask=boost_control_ids,synonyms_control_ids"
+  object_id = "default_search"
+
+  # Since the default serving config is created automatically with the datastore, we need to update
+  # even on initial Terraform resource creation
+  create_method = "PATCH"
+  create_path   = "/engines/${restapi_object.discovery_engine_engine.object_id}/servingConfigs/default_search?updateMask=boost_control_ids,synonyms_control_ids"
+  update_method = "PATCH"
+  update_path   = "/engines/${restapi_object.discovery_engine_engine.object_id}/servingConfigs/default_search?updateMask=boost_control_ids,synonyms_control_ids"
+  read_path     = "/engines/${restapi_object.discovery_engine_engine.object_id}/servingConfigs/default_search"
+
+  data = jsonencode({
+    boostControlIds    = keys(local.boostControls)
+    synonymsControlIds = keys(local.synonymControls)
+  })
+}
+
+resource "restapi_object" "discovery_engine_engine_boost_control" {
+  for_each = local.boostControls
+
+  path      = "/engines/${restapi_object.discovery_engine_engine.object_id}/controls"
+  object_id = each.key
+
+  # API uses query strings to specify ID of the resource to create (not payload)
+  create_path = "/engines/${restapi_object.discovery_engine_engine.object_id}/controls?controlId=${each.key}"
+
+  data = jsonencode({
+    name        = each.key
+    displayName = each.key
+
+    solutionType = "SOLUTION_TYPE_SEARCH"
+    useCases     = ["SEARCH_USE_CASE_SEARCH"]
+
+    boostAction = each.value
+  })
+}
+
+resource "restapi_object" "discovery_engine_engine_synonym_control" {
+  for_each = local.synonymControls
+
+  path      = "/engines/${restapi_object.discovery_engine_engine.object_id}/controls"
+  object_id = each.key
+
+  # API uses query strings to specify ID of the resource to create (not payload)
+  create_path = "/engines/${restapi_object.discovery_engine_engine.object_id}/controls?controlId=${each.key}"
+
+  data = jsonencode({
+    name        = each.key
+    displayName = each.key
+
+    solutionType = "SOLUTION_TYPE_SEARCH"
+    useCases     = ["SEARCH_USE_CASE_SEARCH"]
+
+    synonymsAction = {
+      synonyms = each.value
+    }
+  })
+}


### PR DESCRIPTION
The bug we experienced recently around not being able to attach controls to an engine serving config should have been fixed, so we'll try again.

- Add resource representing the serving config on the engine
- Add controls and attach them to the serving config