### PR TITLE
Disable serving controls for now

### DIFF
--- a/terraform/modules/google_discovery_engine_restapi/main.tf
+++ b/terraform/modules/google_discovery_engine_restapi/main.tf
@@ -96,8 +96,11 @@ resource "restapi_object" "discovery_engine_serving_config" {
   read_path     = "/dataStores/${restapi_object.discovery_engine_datastore.object_id}/servingConfigs/default_search"
 
   data = jsonencode({
-    boostControlIds    = keys(local.boostControls)
-    synonymsControlIds = keys(local.synonymControls)
+    # TODO: Re-enable when we have more clarity on how we will use boosts and which
+    # boostControlIds    = keys(local.boostControls)
+    # synonymsControlIds = keys(local.synonymControls)
+    boostControlIds    = []
+    synonymsControlIds = []
   })
 }
 


### PR DESCRIPTION
We want to experiment with a variety of these as part of automated testing, so we'll unset the default serving controls for now. This will also give us some more time for the bugs with attaching them to an engine to be fixed.