### PR TITLE
Autoeval project id hardcode fix

### DIFF
--- a/terraform/dev_environment/variables.tf
+++ b/terraform/dev_environment/variables.tf
@@ -3,11 +3,6 @@ variable "gcp_project_id" {
   description = "GCP Project ID of the project to create infrastructure in, e.g. search-api-v2-integration"
 }
 
-variable "gcp_project_number" {
-  type        = string
-  description = "GCP Project number"
-}
-
 variable "gcp_region" {
   type        = string
   description = "GCP region to create non-global infrastructure in, e.g. europe-west2"

--- a/terraform/dev_environment/variables.tf
+++ b/terraform/dev_environment/variables.tf
@@ -3,6 +3,11 @@ variable "gcp_project_id" {
   description = "GCP Project ID of the project to create infrastructure in, e.g. search-api-v2-integration"
 }
 
+variable "gcp_project_number" {
+  type        = string
+  description = "GCP Project number"
+}
+
 variable "gcp_region" {
   type        = string
   description = "GCP region to create non-global infrastructure in, e.g. europe-west2"

--- a/terraform/full_environment/automated_evaluation.tf
+++ b/terraform/full_environment/automated_evaluation.tf
@@ -44,7 +44,7 @@ resource "google_cloudfunctions2_function" "automated_evaluation" {
     ingress_settings      = "ALLOW_INTERNAL_ONLY"
     service_account_email = google_service_account.automated_evaluation_pipeline.email
     environment_variables = {
-      PROJECT_NAME = var.gcp_project_id,
+      PROJECT_NAME = var.gcp_project_id
     }
   }
 }
@@ -59,7 +59,7 @@ resource "google_cloud_scheduler_job" "daily_search_evaluation" {
   http_target {
     http_method = "POST"
     uri         = google_cloudfunctions2_function.automated_evaluation.url
-    body        = base64encode(templatefile("${path.module}/files/automated_evaluation_default_datasets/config.tftpl", { judgement_list_names = [for file_jl in fileset("${path.module}/files/automated_evaluation_default_datasets/judgement_lists/", "*.csv") : split(".csv", file_jl)[0]], gcs_input_url = join("", ["gcs://", google_storage_bucket.automated_evaluation_judgement_lists.name, "/"]), gcs_output_url = join("", ["gcs://", google_storage_bucket.automated_evaluation_output.name]) }))
+    body        = base64encode(templatefile("${path.module}/files/automated_evaluation_default_datasets/config.tftpl", { judgement_list_names = [for file_jl in fileset("${path.module}/files/automated_evaluation_default_datasets/judgement_lists/", "*.csv") : split(".csv", file_jl)[0]], gcs_input_url = join("", ["gcs://", google_storage_bucket.automated_evaluation_judgement_lists.name, "/"]), gcs_output_url = join("", ["gcs://", google_storage_bucket.automated_evaluation_output.name]), gcp_project_number = var.gcp_project_number }))
 
     headers = {
       "Content-Type" = "application/json"

--- a/terraform/full_environment/files/automated_evaluation_default_datasets/config.tftpl
+++ b/terraform/full_environment/files/automated_evaluation_default_datasets/config.tftpl
@@ -13,7 +13,7 @@
   "candidates": [
     {
       "name": "vertex_integration",
-      "identifier": "projects/780375417592/locations/global/collections/default_collection/dataStores/govuk_content/servingConfigs/default_search",
+      "identifier": "projects/${gcp_project_number}/locations/global/collections/default_collection/dataStores/govuk_content/servingConfigs/default_search",
       "type": "vertex:search",
       "attributes": {
         "document.structData.link": "docno",

--- a/terraform/full_environment/variables.tf
+++ b/terraform/full_environment/variables.tf
@@ -3,6 +3,11 @@ variable "gcp_project_id" {
   description = "GCP Project ID of the project to create infrastructure in, e.g. search-api-v2-integration"
 }
 
+variable "gcp_project_number" {
+  type        = string
+  description = "GCP Project number"
+}
+
 variable "gcp_analytics_project_id" {
   type        = string
   description = "GCP project ID for the project containing BigQuery analytics data"


### PR DESCRIPTION
Was using hard coded dev project number within the config.tftpl autoeval

file instead of an environment specific variable.