### PR TITLE
Amend Discovery Engine schema with new fields

### DIFF
--- a/terraform/modules/google_discovery_engine_restapi/files/datastore_schema.json
+++ b/terraform/modules/google_discovery_engine_restapi/files/datastore_schema.json
@@ -120,7 +120,37 @@
         "additionalProperties": false
       }
     },
+    "organisations": {
+      "description": "A list of organisation slugs this content belongs to (for filtering)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "indexable": true
+    },
+    "topical_events": {
+      "description": "A list of topical events slugs this content belongs to (for filtering)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "indexable": true
+    },
+    "world_locations": {
+      "description": "A list of world locations slugs this content belongs to (for filtering)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "indexable": true
+    },
+    "manual": {
+      "description": "The manual this content belongs to (if applicable) (for filtering)",
+      "type": "string",
+      "indexable": true
+    },
     "payload_version": {
+      "$comment": "We've decided not to use this in the end as there isn't enough of a risk and we cannot guarantee atomic writes anyway. Vertex does not support removing a field from the schema (as of Jan 2024) so it stays here.",
       "description": "Incrementing document version number (used to avoid document update race conditions)",
       "type": "integer"
     }


### PR DESCRIPTION
- Add `organisations`, `topical_events`, `world_locations`, and `manual` fields for use in filtering
- Add comment to clarify that `payload_version` is no longer used but cannot be removed due to API limitations