### PR TITLE
Fix `indexable` annotations in DE schema

### DIFF
--- a/terraform/modules/google_discovery_engine_restapi/files/datastore_schema.json
+++ b/terraform/modules/google_discovery_engine_restapi/files/datastore_schema.json
@@ -124,25 +124,25 @@
       "description": "A list of organisation slugs this content belongs to (for filtering)",
       "type": "array",
       "items": {
-        "type": "string"
-      },
-      "indexable": true
+        "type": "string",
+        "indexable": true
+      }
     },
     "topical_events": {
       "description": "A list of topical events slugs this content belongs to (for filtering)",
       "type": "array",
       "items": {
-        "type": "string"
-      },
-      "indexable": true
+        "type": "string",
+        "indexable": true
+      }
     },
     "world_locations": {
       "description": "A list of world locations slugs this content belongs to (for filtering)",
       "type": "array",
       "items": {
-        "type": "string"
-      },
-      "indexable": true
+        "type": "string",
+        "indexable": true
+      }
     },
     "manual": {
       "description": "The manual this content belongs to (if applicable) (for filtering)",


### PR DESCRIPTION
These belong against the `items`, not the parent array.