### PR TITLE
Recreate and set `force_destroy` on logs bucket

### DIFF
--- a/terraform/full_environment/events_ingestion.tf
+++ b/terraform/full_environment/events_ingestion.tf
@@ -83,6 +83,12 @@ data "archive_file" "analytics_transfer_function" {
   output_path = "${path.module}/files/analytics_transfer_function.zip"
 }
 
+resource "google_storage_bucket" "vertex_event_ingestion_error_logs" {
+  name          = "${var.gcp_project_id}_vertex_event_ingestion_error_logs"
+  force_destroy = true
+  location      = var.gcp_region
+}
+
 # gen 2 function for transferring from bq - ga4 to bq - vertex events schema
 resource "google_cloudfunctions2_function" "function_analytics_events_transfer" {
   name        = "function_analytics_events_transfer"


### PR DESCRIPTION
The creation of this bucket was reverted but it failed to delete, leaving TF state in a half-applied state. Re-adding it in temporarily with `force_destroy` set so we can remove it in a subsequent commit and have it properly deleted.