### PR TITLE
Remove `vertex_event_ingestion_error_logs` bucket

### DIFF
--- a/terraform/full_environment/events_ingestion.tf
+++ b/terraform/full_environment/events_ingestion.tf
@@ -83,12 +83,6 @@ data "archive_file" "analytics_transfer_function" {
   output_path = "${path.module}/files/analytics_transfer_function.zip"
 }
 
-resource "google_storage_bucket" "vertex_event_ingestion_error_logs" {
-  name          = "${var.gcp_project_id}_vertex_event_ingestion_error_logs"
-  force_destroy = true
-  location      = var.gcp_region
-}
-
 # gen 2 function for transferring from bq - ga4 to bq - vertex events schema
 resource "google_cloudfunctions2_function" "function_analytics_events_transfer" {
   name        = "function_analytics_events_transfer"


### PR DESCRIPTION
This was part of a previous revert but failed to delete, so we set `force_destroy` in 4cf18431c446781a3416d7789296e540d68743ae.