### PR TITLE
Set GCP quotas for Discovery Engine

### DIFF
--- a/terraform/meta/README.md
+++ b/terraform/meta/README.md
@@ -27,3 +27,26 @@ Before you can use this module, you must:
 - use `gcloud auth application-default login` to authenticate to GCP
 - specify values for `google_cloud_folder` and `google_cloud_billing_account` as parameters to
   `terraform` or through a (gitignored) `local.auto.tfvars` file
+
+## Additional information
+### Adding additional GCP quota overrides
+Quota overrides on GCP are somewhat complex to set up and use inconsistent terminology between the
+console UI, the REST API, and the (beta) Terraform provider. In particular, it can be somewhat
+confusing to figure out the `limit` value for the `google_service_usage_consumer_quota_override`
+resource (which actually corresponds to the `unit` field in the API but with different syntax), and
+to find the internal (not display) name of quotas.
+
+If you need to set up a new `google_service_usage_consumer_quota_override` resource for a Discovery
+Engine project, the best way of finding out these values is to make a GET request to the
+`consumerQuotaMetrics` endpoint like so:
+
+```bash
+curl -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+-H "Content-Type: application/json" \
+"https://serviceusage.googleapis.com/v1beta1/projects/${GCP_PROJECT}/services/discoveryengine.googleapis.com/consumerQuotaMetrics" \
+| jq -r '.metrics[] | "\(.displayName): \(.consumerQuotaLimits[0].metric) (\(.consumerQuotaLimits[0].unit | gsub("[1\\{\\}]";"")))"' \
+| sort
+```
+
+This returns a list of available quotas by display name, complete with the necessary `metric` and
+`unit` values.

--- a/terraform/meta/main.tf
+++ b/terraform/meta/main.tf
@@ -95,4 +95,12 @@ module "environment_production" {
   display_name                = "Production"
   has_deployed_service_in_aws = true
   terraform_module            = "full_environment"
+
+  # NOTE: There are limits on the Google side on how high we are permitted to set these quotas. If
+  # you attempt to increase these beyond the ceiling, a `COMMON_QUOTA_CONSUMER_OVERRIDE_TOO_HIGH`
+  # error will be raised (including some metadata that should tell you what the current ceiling is)
+  # and you will need to manually request a quota increase from Google through the console first
+  # (see the environment module for the exact quota names you need to request increases for).
+  discovery_engine_quota_search_requests_per_minute = 1000
+  discovery_engine_quota_documents                  = 2000000
 }

--- a/terraform/meta/modules/environment/variables.tf
+++ b/terraform/meta/modules/environment/variables.tf
@@ -56,6 +56,18 @@ variable "google_cloud_apis" {
   ]
 }
 
+variable "discovery_engine_quota_search_requests_per_minute" {
+  type        = number
+  description = "The maximum number of search requests per minute for the Discovery Engine"
+  default     = 250
+}
+
+variable "discovery_engine_quota_documents" {
+  type        = number
+  description = "The maximum number of documents across Discovery Engine datastores"
+  default     = 1000000
+}
+
 variable "tfc_project" {
   type = object({
     id   = string


### PR DESCRIPTION
- Add "consumer quota override" resources for the number of search
  requests per minute and total number of documents across datastores
- Add required `google-beta` provider
- Set reasonable increased values for production (to be reviewed further
  before we go fully live)
- Add some documentation and helpful commands for figuring out what the
  internal (non-display) naming and units are for quotas