### PR TITLE
ammended schema and sql to select and insert tagIds

### DIFF
--- a/terraform/full_environment/files/search-event-schema.json
+++ b/terraform/full_environment/files/search-event-schema.json
@@ -20,6 +20,11 @@
     "mode": "NULLABLE"
   },
   {
+    "name": "tagIds",
+    "type": "STRING",
+    "mode": "REPEATED"
+  },
+  {
     "name": "documents",
     "type": "RECORD",
     "mode": "REPEATED",


### PR DESCRIPTION
amended the search-event-schema to add the tagIds repeated field to the search-event BQ table. Amended the SQL to select and insert that in the new tagIds field.