### PR TITLE
Re-enable auto apply for TFC workspaces

### DIFF
--- a/terraform/meta/modules/environment/main.tf
+++ b/terraform/meta/modules/environment/main.tf
@@ -84,7 +84,7 @@ resource "tfe_workspace" "environment_workspace" {
 
   execution_mode    = "remote"
   working_directory = "terraform/environment"
-  auto_apply        = false
+  auto_apply        = true
   terraform_version = "~> 1.6.3"
 
   file_triggers_enabled = true


### PR DESCRIPTION
The dev environment removal and associated module rename went fine, so we can re-enable auto apply.