### PR TITLE
Disabled SEARCH_ADD_ON_LLM in engine config

### DIFF
--- a/terraform/modules/google_discovery_engine_restapi/main.tf
+++ b/terraform/modules/google_discovery_engine_restapi/main.tf
@@ -74,7 +74,7 @@ resource "restapi_object" "discovery_engine_engine" {
     },
     searchEngineConfig = {
       searchTier   = var.search_tier,
-      searchAddOns = ["SEARCH_ADD_ON_LLM"] # this is the only valid value supported by the API
+      searchAddOns = [] # "SEARCH_ADD_ON_LLM" is the only valid value supported by the API - leave empty to disable
     }
   })
 }


### PR DESCRIPTION
Removed the `SEARCH_ADD_ON_LLM` setting from the engine config to disable Advanced LLM features (Search summarisation,Search with follow-ups). These features are not required for GOV.UK Search at this time and enabling it has a consumption cost impact