### PR TITLE
Increase production DE quota to final-ish value

### DIFF
--- a/terraform/meta/main.tf
+++ b/terraform/meta/main.tf
@@ -76,6 +76,6 @@ module "environment_production" {
   # error will be raised (including some metadata that should tell you what the current ceiling is)
   # and you will need to manually request a quota increase from Google through the console first
   # (see the environment module for the exact quota names you need to request increases for).
-  discovery_engine_quota_search_requests_per_minute = 2000
+  discovery_engine_quota_search_requests_per_minute = 20000
   discovery_engine_quota_documents                  = 2000000
 }


### PR DESCRIPTION
Now that we're about to go live to all users, increase the quota for search requests per minute to a safe value (to possibly be adjusted downwards later if we're happy we don't need it as high).