### PR TITLE
Remove topical events boost for now

### DIFF
--- a/terraform/modules/google_discovery_engine_restapi/files/controls/boosts.yml
+++ b/terraform/modules/google_discovery_engine_restapi/files/controls/boosts.yml
@@ -10,7 +10,7 @@
 # and https://cloud.google.com/retail/docs/filter-and-order for `filter` syntax
 
 boost_promote_medium:
-  filter: 'content_purpose_supergroup: ANY("services") OR document_type: ANY("calendar", "detailed_guide", "document_collection", "external_content", "organisation", "topical_event")'
+  filter: 'content_purpose_supergroup: ANY("services") OR document_type: ANY("calendar", "detailed_guide", "document_collection", "external_content", "organisation")'
   boost: 0.2
 
 boost_promote_low:


### PR DESCRIPTION
We're anticipating this causing some issues by boosting legacy content over some new content to be released today.