### PR TITLE
"Staged rollout" for TFC environment workspaces

### DIFF
--- a/terraform/meta/main.tf
+++ b/terraform/meta/main.tf
@@ -56,7 +56,9 @@ module "environment_integration" {
 module "environment_staging" {
   source = "./modules/environment"
 
-  name                         = "staging"
+  name                      = "staging"
+  upstream_environment_name = "integration"
+
   google_cloud_billing_account = var.google_cloud_billing_account
   google_cloud_folder          = var.google_cloud_folder
   tfc_project                  = tfe_project.project
@@ -65,7 +67,9 @@ module "environment_staging" {
 module "environment_production" {
   source = "./modules/environment"
 
-  name                         = "production"
+  name                      = "production"
+  upstream_environment_name = "staging"
+
   google_cloud_billing_account = var.google_cloud_billing_account
   google_cloud_folder          = var.google_cloud_folder
   tfc_project                  = tfe_project.project

--- a/terraform/meta/modules/environment/variables.tf
+++ b/terraform/meta/modules/environment/variables.tf
@@ -60,6 +60,12 @@ variable "tfc_project" {
   description = "The Terraform Cloud/Enterprise project to create workspaces under"
 }
 
+variable "upstream_environment_name" {
+  type        = string
+  description = "The name of the upstream environment, if any (used to wait for a successful apply on a 'lower' environment before applying this one)"
+  default     = null
+}
+
 variable "tfc_hostname" {
   type        = string
   description = "The hostname of the Terraform Cloud/Enterprise instance to use"


### PR DESCRIPTION
Instead of all environments auto-applying simultaneously, sets up workspace triggers so that integration/staging/production apply in sequence and only if the "previous" environment applied successfully.