### PR TITLE
Make `is_historic` field retrievable in schema

### DIFF
--- a/terraform/modules/google_discovery_engine_restapi/files/datastore_schema.json
+++ b/terraform/modules/google_discovery_engine_restapi/files/datastore_schema.json
@@ -75,7 +75,8 @@
       "multipleOf": 1,
       "minimum": 0,
       "maximum": 1,
-      "indexable": true
+      "indexable": true,
+      "retrievable": true
     },
     "organisation_state": {
       "description": "The state of the organisation (for boosting)",


### PR DESCRIPTION
This was accidentally set to only be indexable and thus not returned in query results and by extension `search-api-v2`, breaking the ability for Finder Frontend to show whether content is historic.