### PR TITLE
Move execution mode into `tfe_workspace_settings`

### DIFF
--- a/terraform/meta/main.tf
+++ b/terraform/meta/main.tf
@@ -40,6 +40,10 @@ resource "tfe_workspace" "meta_workspace" {
   project_id  = tfe_project.project.id
   description = "Meta workspace for cross-environment TF Cloud resources (state backend only)"
   tag_names   = ["govuk", "search-api-v2"]
+}
+
+resource "tfe_workspace_settings" "meta_workspace_settings" {
+  workspace_id = tfe_workspace.meta_workspace.id
 
   execution_mode = "local"
 }

--- a/terraform/meta/modules/environment/main.tf
+++ b/terraform/meta/modules/environment/main.tf
@@ -86,7 +86,6 @@ resource "tfe_workspace" "environment_workspace" {
   source_name = "search-v2-infrastructure meta module"
   source_url  = "https://github.com/alphagov/search-v2-infrastructure/tree/main/terraform/meta"
 
-  execution_mode    = "remote"
   working_directory = "terraform/environment"
   terraform_version = "~> 1.7.5"
 
@@ -108,6 +107,12 @@ resource "tfe_workspace" "environment_workspace" {
     branch         = "main"
     oauth_token_id = data.tfe_oauth_client.github.oauth_token_id
   }
+}
+
+resource "tfe_workspace_settings" "environment_workspace_settings" {
+  workspace_id = tfe_workspace.environment_workspace.id
+
+  execution_mode = "remote"
 }
 
 # Only relevant for the run trigger, if we have an upstream workspace to wait for


### PR DESCRIPTION
The attribute on `tfe_workspace` resource is deprecated and this now needs to live in a separate `tfe_workspace_settings` resource.