### PR TITLE
Fixes for vertex error on serving config

### DIFF
--- a/terraform/modules/google_discovery_engine_restapi/files/servingConfigs/servingConfigs.yml
+++ b/terraform/modules/google_discovery_engine_restapi/files/servingConfigs/servingConfigs.yml
@@ -11,4 +11,4 @@
 
 search_raw:
   boostControlIds: []
-  synonymControlIds: []
+  synonymsControlIds: []

--- a/terraform/modules/google_discovery_engine_restapi/main.tf
+++ b/terraform/modules/google_discovery_engine_restapi/main.tf
@@ -114,7 +114,7 @@ resource "restapi_object" "discovery_engine_serving_config_additional" {
   path      = "/dataStores/${restapi_object.discovery_engine_datastore.object_id}/servingConfigs"
   object_id = each.key
 
-  create_method = "CREATE"
+  create_method = "POST"
   create_path   = "/dataStores/${restapi_object.discovery_engine_datastore.object_id}/servingConfigs?servingConfigId=${each.key}"
   update_method = "PATCH"
   update_path   = "/dataStores/${restapi_object.discovery_engine_datastore.object_id}/servingConfigs/${each.key}"


### PR DESCRIPTION
2 fixes included:-
* create_method changed to `POST` to match default - https://registry.terraform.io/providers/Mastercard/restapi/latest/docs#create_method
* fixed typo in `synonymsControlIds` in `servingConfigs.yml` configuration file