### PR TITLE
Unset key property mapping for `part_of_taxonomy_tree`

### DIFF
--- a/terraform/modules/google_discovery_engine_restapi/files/datastore_schema.json
+++ b/terraform/modules/google_discovery_engine_restapi/files/datastore_schema.json
@@ -66,7 +66,7 @@
       "items": {
         "type": "string",
         "format": "uuid",
-        "keyPropertyMapping": "category"
+        "indexable": true
       }
     },
     "is_historic": {


### PR DESCRIPTION
We originally set up `part_of_taxonomy_tree` with a key property mapping of `category` as that intuitively made sense for an array field dealing with tagging. However, this doesn't actually add any practical value, and results in the field being limited to a maximum of 250 items (which isn't enough for a small long tail of content).

This removes the mapping from the field and just sets the `indexable` property instead so it is treated as a regular field.