### PR TITLE
Remove `import`/`deleted` blocks for datastore

### DIFF
--- a/terraform/environment/discovery_engine.tf
+++ b/terraform/environment/discovery_engine.tf
@@ -15,13 +15,6 @@ locals {
   discovery_engine_serving_config_path   = "${google_discovery_engine_data_store.govuk_content.name}/servingConfigs/default_search"
 }
 
-# This is currently managed by our custom RESTAPI module, moving to a first party resource
-# TODO: This block can be deleted once successfully applied in all environments
-import {
-  id = "projects/${var.gcp_project_id}/locations/global/collections/default_collection/dataStores/govuk_content"
-  to = google_discovery_engine_data_store.govuk_content
-}
-
 resource "google_discovery_engine_data_store" "govuk_content" {
   data_store_id = "govuk_content"
   display_name  = "govuk_content"

--- a/terraform/modules/google_discovery_engine_restapi/main.tf
+++ b/terraform/modules/google_discovery_engine_restapi/main.tf
@@ -15,16 +15,6 @@ locals {
   synonymControls = yamldecode(file("${path.module}/files/controls/synonyms.yml"))
 }
 
-# This has been moved into a first party resource in terraform/environment/discovery_engine.tf
-# TODO: This block can be deleted once successfully applied in all environments
-removed {
-  from = restapi_object.discovery_engine_datastore
-
-  lifecycle {
-    destroy = false
-  }
-}
-
 # The data schema for the datastore
 #
 # The API resource relationship is one-to-many, but currently only a single schema is supported and


### PR DESCRIPTION
These have now successfully applied in all environments and can be removed.