### PR TITLE
Migrate to `google_discovery_engine_search_engine`

### DIFF
--- a/terraform/environment/discovery_engine.tf
+++ b/terraform/environment/discovery_engine.tf
@@ -5,7 +5,6 @@ module "govuk_content_discovery_engine" {
   source = "../modules/google_discovery_engine_restapi"
 
   datastore_id = "govuk_content"
-  engine_id    = "govuk"
 }
 
 # TODO: These IDs/paths are semi-hardcoded here as there aren't first party resources/data sources
@@ -23,6 +22,36 @@ resource "google_discovery_engine_data_store" "govuk_content" {
   industry_vertical = "GENERIC"
   content_config    = "CONTENT_REQUIRED" # == "unstructured" datastore
   solution_types    = ["SOLUTION_TYPE_SEARCH"]
+}
+
+# TODO: Remove after change has been applied in all environments
+import {
+  id = "global/default_collection/govuk"
+  to = google_discovery_engine_search_engine.govuk
+}
+
+resource "google_discovery_engine_search_engine" "govuk" {
+  engine_id    = "govuk"
+  display_name = "GOV.UK Site Search"
+
+  location      = google_discovery_engine_data_store.govuk_content.location
+  collection_id = "default_collection"
+
+  # TODO: The engine was originally created before this field existed. It now defaults to "GENERIC",
+  # but while migrating to the first party resource we need to force it to a blank string so it
+  # doesn't get replaced.
+  industry_vertical = ""
+
+  data_store_ids = [google_discovery_engine_data_store.govuk_content.data_store_id]
+
+  search_engine_config {
+    search_tier    = "SEARCH_TIER_STANDARD"
+    search_add_ons = []
+  }
+
+  common_config {
+    company_name = "GOV.UK"
+  }
 }
 
 resource "aws_secretsmanager_secret" "discovery_engine_configuration" {

--- a/terraform/modules/google_discovery_engine_restapi/main.tf
+++ b/terraform/modules/google_discovery_engine_restapi/main.tf
@@ -36,30 +36,13 @@ resource "restapi_object" "discovery_engine_datastore_schema" {
   })
 }
 
-# The engine used for querying the datastore
-#
-# API resource: v1alpha.projects.locations.collections.engines
-resource "restapi_object" "discovery_engine_engine" {
-  path      = "/engines"
-  object_id = var.engine_id
+# TODO: Remove after change has been applied in all environments
+removed {
+  from = restapi_object.discovery_engine_engine
 
-  # API uses query strings to specify ID of the resource to create (not payload)
-  create_path = "/engines?engineId=${var.engine_id}"
-
-  data = jsonencode({
-    displayName = var.engine_id,
-    dataStoreIds = [
-      var.datastore_id
-    ],
-    solutionType = "SOLUTION_TYPE_SEARCH",
-    commonConfig = {
-      companyName = "GOV.UK"
-    },
-    searchEngineConfig = {
-      searchTier   = var.search_tier,
-      searchAddOns = [] # "SEARCH_ADD_ON_LLM" is the only valid value supported by the API - leave empty to disable
-    }
-  })
+  lifecycle {
+    destroy = false
+  }
 }
 
 resource "restapi_object" "discovery_engine_serving_config" {

--- a/terraform/modules/google_discovery_engine_restapi/variables.tf
+++ b/terraform/modules/google_discovery_engine_restapi/variables.tf
@@ -2,14 +2,3 @@ variable "datastore_id" {
   description = "The name of the datastore to create"
   type        = string
 }
-
-variable "engine_id" {
-  description = "The name of the engine to create"
-  type        = string
-}
-
-variable "search_tier" {
-  type        = string
-  description = "The tier of the Discovery Engine to use, e.g. STANDARD or ENTERPRISE"
-  default     = "SEARCH_TIER_STANDARD"
-}


### PR DESCRIPTION
This is the next step towards using more of the first party Google provider resources for Vertex AI Search (Vertex AI Agent Builder).