### PR TITLE
Add controls and serving config resources to engine

### DIFF
--- a/terraform/environment/discovery_engine.tf
+++ b/terraform/environment/discovery_engine.tf
@@ -4,7 +4,8 @@
 module "govuk_content_discovery_engine" {
   source = "../modules/google_discovery_engine_restapi"
 
-  datastore_id = "govuk_content"
+  datastore_id = google_discovery_engine_data_store.govuk_content.data_store_id
+  engine_id    = google_discovery_engine_search_engine.govuk.engine_id
 }
 
 # TODO: These IDs/paths are semi-hardcoded here as there aren't first party resources/data sources

--- a/terraform/modules/google_discovery_engine_restapi/main.tf
+++ b/terraform/modules/google_discovery_engine_restapi/main.tf
@@ -15,6 +15,8 @@ locals {
   synonymControls = yamldecode(file("${path.module}/files/controls/synonyms.yml"))
 }
 
+############## DATASTORE ##############
+
 # The data schema for the datastore
 #
 # The API resource relationship is one-to-many, but currently only a single schema is supported and
@@ -113,6 +115,73 @@ resource "restapi_object" "discovery_engine_synonym_control" {
 
   # API uses query strings to specify ID of the resource to create (not payload)
   create_path = "/dataStores/${var.datastore_id}/controls?controlId=${each.key}"
+
+  data = jsonencode({
+    name        = each.key
+    displayName = each.key
+
+    solutionType = "SOLUTION_TYPE_SEARCH"
+    useCases     = ["SEARCH_USE_CASE_SEARCH"]
+
+    synonymsAction = {
+      synonyms = each.value
+    }
+  })
+}
+
+############## ENGINE ##############
+
+resource "restapi_object" "discovery_engine_serving_config_engine" {
+  depends_on = [
+    restapi_object.discovery_engine_boost_control_engine,
+    restapi_object.discovery_engine_synonym_control_engine
+  ]
+
+  path      = "/engines/${var.engine_id}/servingConfigs/default_search?updateMask=boost_control_ids,synonyms_control_ids"
+  object_id = "default_search"
+
+  # Since the default serving config is created automatically with the datastore, we need to update
+  # even on initial Terraform resource creation
+  create_method = "PATCH"
+  create_path   = "/engines/${var.engine_id}/servingConfigs/default_search?updateMask=boost_control_ids,synonyms_control_ids"
+  update_method = "PATCH"
+  update_path   = "/engines/${var.engine_id}/servingConfigs/default_search?updateMask=boost_control_ids,synonyms_control_ids"
+  read_path     = "/engines/${var.engine_id}/servingConfigs/default_search"
+
+  data = jsonencode({
+    boostControlIds    = keys(local.boostControls)
+    synonymsControlIds = keys(local.synonymControls)
+  })
+}
+
+resource "restapi_object" "discovery_engine_boost_control_engine" {
+  for_each = local.boostControls
+
+  path      = "/engines/${var.engine_id}/controls"
+  object_id = each.key
+
+  # API uses query strings to specify ID of the resource to create (not payload)
+  create_path = "/engines/${var.engine_id}/controls?controlId=${each.key}"
+
+  data = jsonencode({
+    name        = each.key
+    displayName = each.key
+
+    solutionType = "SOLUTION_TYPE_SEARCH"
+    useCases     = ["SEARCH_USE_CASE_SEARCH"]
+
+    boostAction = each.value
+  })
+}
+
+resource "restapi_object" "discovery_engine_synonym_control_engine" {
+  for_each = local.synonymControls
+
+  path      = "/engines/${var.engine_id}/controls"
+  object_id = each.key
+
+  # API uses query strings to specify ID of the resource to create (not payload)
+  create_path = "/engines/${var.engine_id}/controls?controlId=${each.key}"
 
   data = jsonencode({
     name        = each.key

--- a/terraform/modules/google_discovery_engine_restapi/variables.tf
+++ b/terraform/modules/google_discovery_engine_restapi/variables.tf
@@ -1,4 +1,9 @@
 variable "datastore_id" {
-  description = "The name of the datastore to create"
+  description = "The name of the datastore to create resources against"
+  type        = string
+}
+
+variable "engine_id" {
+  description = "The name of the engine to create resources against"
   type        = string
 }


### PR DESCRIPTION
This set of changes attempts to create the first batch of resources that we want to have against the datastore against the engine too.

- Add engine ID var to restapi module
- Make engine and datastore ID config dynamic from TF resource
- Add initial controls and serving config to engine