### PR TITLE
Remove `removed` block after successful apply

### DIFF
--- a/terraform/modules/google_discovery_engine_restapi/main.tf
+++ b/terraform/modules/google_discovery_engine_restapi/main.tf
@@ -131,13 +131,3 @@ resource "restapi_object" "discovery_engine_synonym_control" {
     }
   })
 }
-
-# Remove now unnecessary extra engine serving config from state
-# TODO: Remove after change has been applied in all environments
-removed {
-  from = restapi_object.discovery_engine_serving_config_engine
-
-  lifecycle {
-    destroy = false
-  }
-}


### PR DESCRIPTION
The engine change has applied in all envs so this can be taken out.