### PR TITLE
Migrate controls to live on engine, not datastore

### DIFF
--- a/terraform/modules/google_discovery_engine_restapi/main.tf
+++ b/terraform/modules/google_discovery_engine_restapi/main.tf
@@ -93,11 +93,11 @@ resource "restapi_object" "discovery_engine_serving_config_additional" {
 resource "restapi_object" "discovery_engine_boost_control" {
   for_each = local.boostControls
 
-  path      = "/dataStores/${var.datastore_id}/controls"
+  path      = "/engines/${var.engine_id}/controls"
   object_id = each.key
 
   # API uses query strings to specify ID of the resource to create (not payload)
-  create_path = "/dataStores/${var.datastore_id}/controls?controlId=${each.key}"
+  create_path = "/engines/${var.engine_id}/controls?controlId=${each.key}"
 
   data = jsonencode({
     name        = each.key
@@ -113,11 +113,11 @@ resource "restapi_object" "discovery_engine_boost_control" {
 resource "restapi_object" "discovery_engine_synonym_control" {
   for_each = local.synonymControls
 
-  path      = "/dataStores/${var.datastore_id}/controls"
+  path      = "/engines/${var.engine_id}/controls"
   object_id = each.key
 
   # API uses query strings to specify ID of the resource to create (not payload)
-  create_path = "/dataStores/${var.datastore_id}/controls?controlId=${each.key}"
+  create_path = "/engines/${var.engine_id}/controls?controlId=${each.key}"
 
   data = jsonencode({
     name        = each.key


### PR DESCRIPTION
As with the serving config changes, this should not actually change anything under the hood as these resources are available identically on both the engine and the datastore in a "symlink" sort of fashion.