### PR TITLE
Add `public_timestamp_datetime` field to schema

### DIFF
--- a/terraform/modules/google_discovery_engine_restapi/files/datastore_schema.json
+++ b/terraform/modules/google_discovery_engine_restapi/files/datastore_schema.json
@@ -48,6 +48,12 @@
       "retrievable": true,
       "indexable": true
     },
+    "public_timestamp_datetime": {
+      "description": "RFC3339 timestamp of when this object was last updated (for boosting and displaying)",
+      "type": "datetime",
+      "retrievable": true,
+      "indexable": true
+    },
     "document_type": {
       "description": "The source document type (for boosting)",
       "type": "string",


### PR DESCRIPTION
We have been using manual boosting and sorting on the `public_timestamp` field as an integer until now.

Discovery Engine now supports datetime fields in RFC3339 format for both a new freshness boosting feature as well as sorting, so we should be able to deprecate the existing `public_timestamp` field and use this one going forwards.