### PR TITLE
Re-add `category` key property mapping

### DIFF
--- a/terraform/modules/google_discovery_engine_restapi/files/datastore_schema.json
+++ b/terraform/modules/google_discovery_engine_restapi/files/datastore_schema.json
@@ -69,6 +69,7 @@
     "part_of_taxonomy_tree": {
       "description": "A list of GOV.UK taxon IDs that this content object is tagged to (for filtering)",
       "type": "array",
+      "keyPropertyMapping": "category",
       "items": {
         "type": "string",
         "format": "uuid",


### PR DESCRIPTION
This reverts #261 as it turns out removing an existing key property mapping from a field is not a valid schema operation and it's causing schema apply issues.