### PR TITLE
Set `category` key property mapping correctly

### DIFF
--- a/terraform/modules/google_discovery_engine_restapi/files/datastore_schema.json
+++ b/terraform/modules/google_discovery_engine_restapi/files/datastore_schema.json
@@ -69,9 +69,9 @@
     "part_of_taxonomy_tree": {
       "description": "A list of GOV.UK taxon IDs that this content object is tagged to (for filtering)",
       "type": "array",
-      "keyPropertyMapping": "category",
       "items": {
         "type": "string",
+        "keyPropertyMapping": "category",
         "format": "uuid",
         "indexable": true
       }


### PR DESCRIPTION
This needs to go on individual elements in the array, not the field itself.