### PR TITLE
Remove `indexable` annotation from field

### DIFF
--- a/terraform/modules/google_discovery_engine_restapi/files/datastore_schema.json
+++ b/terraform/modules/google_discovery_engine_restapi/files/datastore_schema.json
@@ -72,8 +72,7 @@
       "items": {
         "type": "string",
         "keyPropertyMapping": "category",
-        "format": "uuid",
-        "indexable": true
+        "format": "uuid"
       }
     },
     "is_historic": {


### PR DESCRIPTION
This is implied by the key property mapping anyway and apparently conflicts with it.