### PR TITLE
Add service account for UI prototype

### DIFF
--- a/terraform/environment/outputs.tf
+++ b/terraform/environment/outputs.tf
@@ -12,3 +12,8 @@ output "google_cloud_discovery_engine_serving_config_path" {
   description = "The full path of the default serving config on the engine created by the module (for querying)"
   value       = local.discovery_engine_serving_config_path
 }
+
+output "prototype_service_account_key" {
+  description = "The key for the prototype service account (to be added to Heroku)"
+  value       = base64decode(google_service_account_key.prototype.private_key)
+}

--- a/terraform/environment/prototype.tf
+++ b/terraform/environment/prototype.tf
@@ -1,0 +1,33 @@
+# Creates and configures service accounts, IAM roles, role bindings, and keys for a UI prototype to
+# access Discovery Engine on a read-only basis.
+# TODO: Remove this once the prototype is no longer needed.
+
+resource "google_service_account" "prototype" {
+  account_id   = "search-ui-prototype"
+  display_name = "search-ui-prototype (research prototype)"
+  description  = "Service account to provide read-only access to the Discovery Engine API for the Search UI prototype"
+}
+
+resource "google_service_account_key" "prototype" {
+  service_account_id = google_service_account.prototype.id
+}
+
+resource "google_project_iam_custom_role" "prototype" {
+  role_id     = "search_ui_prototype"
+  title       = "search-ui-prototype"
+  description = "Provides the required permissions for the Search UI prototype to access Discovery Engine"
+
+  permissions = [
+    "discoveryengine.servingConfigs.search",
+    "discoveryengine.dataStores.completeQuery",
+  ]
+}
+
+resource "google_project_iam_binding" "prototype" {
+  project = var.gcp_project_id
+  role    = google_project_iam_custom_role.prototype.id
+
+  members = [
+    google_service_account.prototype.member
+  ]
+}


### PR DESCRIPTION
We'll soon start working on a UI prototype for some upcoming interface improvements for search.

This will (probably) live on Heroku, and get its own set of keys to access GCP and relevant Discovery Engine resources on a read-only basis.

For now, it gets the minimum set of permissions necessary to perform search and autocomplete requests.