### PR TITLE
Mark prototype key output as sensitive

### DIFF
--- a/terraform/environment/outputs.tf
+++ b/terraform/environment/outputs.tf
@@ -16,4 +16,5 @@ output "google_cloud_discovery_engine_serving_config_path" {
 output "prototype_service_account_key" {
   description = "The key for the prototype service account (to be added to Heroku)"
   value       = base64decode(google_service_account_key.prototype.private_key)
+  sensitive   = true
 }


### PR DESCRIPTION
This is explicitly required to allow Terraform to output this value.