### PR TITLE
Add separate engine for UI prototype

### DIFF
--- a/terraform/environment/outputs.tf
+++ b/terraform/environment/outputs.tf
@@ -18,3 +18,8 @@ output "prototype_service_account_key" {
   value       = base64decode(google_service_account_key.prototype.private_key)
   sensitive   = true
 }
+
+output "prototype_discovery_engine_serving_config_path" {
+  description = "The full path of the default serving config for the UI prototype's engine"
+  value       = local.prototype_discovery_engine_serving_config_path
+}

--- a/terraform/environment/prototype.tf
+++ b/terraform/environment/prototype.tf
@@ -2,6 +2,33 @@
 # access Discovery Engine on a read-only basis.
 # TODO: Remove this once the prototype is no longer needed.
 
+locals {
+  prototype_discovery_engine_serving_config_path = "${google_discovery_engine_search_engine.ui_prototype.name}/servingConfigs/default_search"
+}
+
+# Additional engine specifically for the UI prototype, allowing us to enable a higher search tier
+# and add ons without risking accidentally using them in production (expensive!).
+resource "google_discovery_engine_search_engine" "ui_prototype" {
+  engine_id    = "ui_prototype"
+  display_name = "Search UI Prototype"
+
+  location      = google_discovery_engine_data_store.govuk_content.location
+  collection_id = "default_collection"
+
+  industry_vertical = "GENERIC"
+
+  data_store_ids = [google_discovery_engine_data_store.govuk_content.data_store_id]
+
+  search_engine_config {
+    search_tier    = "SEARCH_TIER_ENTERPRISE"
+    search_add_ons = ["SEARCH_ADD_ON_LLM"]
+  }
+
+  common_config {
+    company_name = "GOV.UK"
+  }
+}
+
 resource "google_service_account" "prototype" {
   account_id   = "search-ui-prototype"
   display_name = "search-ui-prototype (research prototype)"


### PR DESCRIPTION
We want to be able to experiment with some advanced Vertex AI Search features in the UI prototype. These come at a cost, and we've specifically disabled them in the production engine to make sure we don't accidentally get charged.

This creates a new engine with the features enabled (enterprise tier and LLM add-on) specifically for use by the UI prototype, leaving the existing production engine unchanged.