### PR TITLE
Added TF for default completion configuration

### DIFF
--- a/terraform/modules/google_discovery_engine_restapi/main.tf
+++ b/terraform/modules/google_discovery_engine_restapi/main.tf
@@ -131,3 +131,22 @@ resource "restapi_object" "discovery_engine_synonym_control" {
     }
   })
 }
+
+resource "restapi_object" "discovery_engine_datastore_completion_config" {
+  path      = "/dataStores/${var.datastore_id}/completionConfig"
+  object_id = ""
+
+  # Since the default completionConfig is created automatically with the datastore, we need to update even on
+  # initial Terraform resource creation
+  create_method = "PATCH"
+  create_path   = "/dataStores/${var.datastore_id}/completionConfig"
+
+  data = jsonencode({
+    name            = "comletionConfig"
+    matchingOrder   = "out-of-order"
+    maxSuggestions  = 5,
+    minPrefixLength = 3,
+    queryModel      = "automatic",
+    enableMode      = "AUTOMATIC"
+  })
+}

--- a/terraform/modules/google_discovery_engine_restapi/main.tf
+++ b/terraform/modules/google_discovery_engine_restapi/main.tf
@@ -142,7 +142,7 @@ resource "restapi_object" "discovery_engine_datastore_completion_config" {
   create_path   = "/dataStores/${var.datastore_id}/completionConfig"
 
   data = jsonencode({
-    name            = "comletionConfig"
+    name            = "completionConfig"
     matchingOrder   = "out-of-order"
     maxSuggestions  = 5,
     minPrefixLength = 3,


### PR DESCRIPTION
Added Terraform code to set the default completion configuration for autocomplete with the following settings:-
* matchingOrder: out-of-order
* maxSuggestions: 5
* minPrefixLength: 3