### PR TITLE
Ignore datastore `solution_types` property drift

### DIFF
--- a/terraform/environment/discovery_engine.tf
+++ b/terraform/environment/discovery_engine.tf
@@ -23,6 +23,15 @@ resource "google_discovery_engine_data_store" "govuk_content" {
   industry_vertical = "GENERIC"
   content_config    = "CONTENT_REQUIRED" # == "unstructured" datastore
   solution_types    = ["SOLUTION_TYPE_SEARCH"]
+
+  lifecycle {
+    ignore_changes = [
+      # TODO: Annoyingly, this field is not updatable by us, but can change internally (and indeed
+      # has changed in integration after some engine experiments). This means we need to ignore
+      # changes to it to avoid unnecessary resource replacements.
+      solution_types
+    ]
+  }
 }
 
 resource "google_discovery_engine_search_engine" "govuk" {


### PR DESCRIPTION
Some properties of some resources on Vertex AI Search can permanently change based on tangentially related changes to other resources, leading to Terraform state drift.

For example, we created a recommendation engine on integration for testing purposes, and it permanently changed the internal state of the datastore it was attached to (despite the engine since having been deleted).

This ignores any post-creation changes to the `solution_types` property to mitigate any consequences of this undesired behaviour (in this case, Terraform trying to recreate the resource as it cannot return the field back to its original state).