### PR TITLE
Add `completeQuery` permission to API service account

### DIFF
--- a/terraform/environment/service_accounts.tf
+++ b/terraform/environment/service_accounts.tf
@@ -17,6 +17,7 @@ resource "google_project_iam_custom_role" "api" {
 
   permissions = [
     "discoveryengine.servingConfigs.search",
+    "discoveryengine.dataStores.completeQuery",
     "discoveryengine.dataStores.get",
     "discoveryengine.documents.create",
     "discoveryengine.documents.delete",


### PR DESCRIPTION
This is needed to use the completion API on VAIS.