### PR TITLE
Add extra permissions to API service account

### DIFF
--- a/terraform/environment/service_accounts.tf
+++ b/terraform/environment/service_accounts.tf
@@ -26,6 +26,9 @@ resource "google_project_iam_custom_role" "api" {
     "discoveryengine.documents.list",
     "discoveryengine.documents.update",
     "discoveryengine.operations.get",
+    "discoveryengine.suggestionDenyListEntries.import",
+    "discoveryengine.suggestionDenyListEntries.purge",
+    "discoveryengine.userEvents.import",
   ]
 }
 


### PR DESCRIPTION
These are needed as we move some tasks from running as GCP Cloud Functions to being Rake tasks in the API app itself.